### PR TITLE
fix issue where whitelist always passes for email validation

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -39,3 +39,32 @@ def test_returns_true_on_valid_email(value, whitelist):
 ])
 def test_returns_failed_validation_on_invalid_email(value):
     assert isinstance(email(value), ValidationFailure)
+
+
+@pytest.mark.parametrize(('value', 'whitelist'), [
+    ('email@here.com', ['foo.here.com']),
+    ('weirder-email@here.and.there.com', ['here.and.there.org']),
+    ('email@[127.0.0.1]', ['[127.0.0.2]']),
+    ('example@valid-----hyphens.com', ['-----hyphens.com']),
+    ('example@valid-with-hyphens.com', ['hyphens.com']),
+    ('email@localhost', ['localdomain']),
+    ('"test@test"@example.com', ['example.org', 'example.net', 'foo.org']),
+    ('"\\\011"@here.com', ['there.com']),
+])
+def test_returns_failed_validation_on_bad_whitelist(value, whitelist):
+    assert isinstance(email(value, whitelist=whitelist, only_whitelist=True),
+                      ValidationFailure)
+
+
+@pytest.mark.parametrize(('value', 'whitelist'), [
+    ('email@here.com', ['here.com']),
+    ('weirder-email@here.and.there.com', ['here.and.there.com']),
+    ('email@[127.0.0.1]', ['[127.0.0.1]']),
+    ('example@valid-----hyphens.com', ['valid-----hyphens.com']),
+    ('example@valid-with-hyphens.com', ['valid-with-hyphens.com']),
+    ('email@localhost', ['localdomain', 'localhost']),
+    ('"test@test"@example.com', ['example.org', 'example.com', 'foo.org']),
+    ('"\\\011"@here.com', ['here.com', 'test.org', 'zeta', 100]),
+])
+def test_returns_true_on_valid_email_and_only_whitelist(value, whitelist):
+    assert email(value, whitelist=whitelist, only_whitelist=True)

--- a/validators/email.py
+++ b/validators/email.py
@@ -46,6 +46,7 @@ def email(value, whitelist=None, only_whitelist=False):
 
     :param value: value to validate
     :param whitelist: domain names to whitelist
+    :param only_whitelist: specify whether to fail non whitelisted domains
 
     :copyright: (c) Django Software Foundation and individual contributors.
     :license: BSD

--- a/validators/email.py
+++ b/validators/email.py
@@ -51,9 +51,6 @@ def email(value, whitelist=None):
     :license: BSD
     """
 
-    if whitelist is None:
-        whitelist = domain_whitelist
-
     if not value or '@' not in value:
         return False
 
@@ -62,11 +59,15 @@ def email(value, whitelist=None):
     if not user_regex.match(user_part):
         return False
 
-    if domain_part not in whitelist and not domain_regex.match(domain_part):
+    if whitelist is not None and domain_part not in whitelist:
         # Try for possible IDN domain-part
-        try:
-            domain_part = domain_part.encode('idna').decode('ascii')
-            return domain_regex.match(domain_part)
-        except UnicodeError:
+        if not domain_regex.match(domain_part):
+            try:
+                domain_part = domain_part.encode('idna').decode('ascii')
+                return domain_regex.match(domain_part)
+            except UnicodeError:
+                return False
+        # Domain is fine but not in whitelist so it's a fail
+        else:
             return False
     return True


### PR DESCRIPTION
So, it looks like the logic was off for the email validation and whitelist keyword. It'd always pass the whitelist if the domain was fine. check the top level if condition in the original code and you see that if it's not in whitelist and the domain_regex passes, it just skips over to return True.

if domain_part not in whitelist and not domain_regex.match(domain_part):

Testing patch:

In [2]: email('test@riskiq.net')
Out[2]: True

In [3]: email('test@riskiq.net', whitelist=['riskiq.net'])
Out[3]: True

In [4]: email('test@riskiq.net', whitelist=['riskiq.com'])
Out[4]: ValidationFailure(func=email, args={'value': 'test@riskiq.net', 'whitelist': ['riskiq.com']})
