### PR TITLE
Expand validators.url to allow FQDNs that have IDNA A-labels

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -75,7 +75,7 @@ from validators import url, ValidationFailure
     u'https://userid:password@xn--fsqu00a.xn--0zwm56d:8080',
     u'https://userid:password@xn--fsqu00a.xn--0zwm56d:8080/foobar'
     u'https://用户名密码:密码@xn--fsqu00a.xn--0zwm56d'
-    u'https://%E7%94%A8%E6%88%B7%E5%90%8D%E5%AF%86%E7%A0%81:%E5%AF%86%E7%A0%81@xn--fsqu00a.xn--0zwm56d'
+    u'https://%E7%94%A8:%E5%AF%86@xn--fsqu00a.xn--0zwm56d'
 ])
 def test_returns_true_on_valid_url(address):
     assert url(address)

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -52,6 +52,30 @@ from validators import url, ValidationFailure
     u'http://127.0.10.150',
     u'http://localhost',
     u'http://localhost:8000',
+    u'http://xn--mgbh0fb.xn--kgbechtv',
+    u'http://xn--mgbh0fb.xn--kgbechtv/',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/',
+    u'http://xn--mgbh0fb.xn--kgbechtv/foobar',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/foobar',
+    u'http://xn--mgbh0fb.xn--kgbechtv/foo/?bar=baz&inga=42&quux',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/foo/?bar=baz&inga=42&quux',
+    u'http://xn--mgbh0fb.xn--kgbechtv/foo_bar',
+    u'http://xn--mgbh0fb.xn--kgbechtv/123',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/123',
+    u'http://xn--mgbh0fb.xn--kgbechtv/?foo=bar%20has-url-encoded%20stuff',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/?foo=bar%20has-url-encoded%20stuff',
+    u'http://xn--mgbh0fb.xn--kgbechtv/foobar_(wikipedia)#cite-1',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/foobar_(wikipedia)#cite-1',
+    u'http://xn--mgbh0fb.xn--kgbechtv/unicode_(✪)_in_parens',
+    u'http://xn--mgbh0fb.xn--kgbechtv:8080/unicode_(✪)_in_parens',
+    u'http://xn--mgbh0fb.xn--kgbechtv/(something)?after=parens',
+    u'ftp://xn--p1b6ci4b4b3a.xn--11b5bs3a9aj6g/foo',
+    u'https://userid:password@xn--fsqu00a.xn--0zwm56d',
+    u'https://userid:password@xn--fsqu00a.xn--0zwm56d:8080',
+    u'https://userid:password@xn--fsqu00a.xn--0zwm56d:8080/foobar'
+    u'https://用户名密码:密码@xn--fsqu00a.xn--0zwm56d'
+    u'https://%E7%94%A8%E6%88%B7%E5%90%8D%E5%AF%86%E7%A0%81:%E5%AF%86%E7%A0%81@xn--fsqu00a.xn--0zwm56d'
 ])
 def test_returns_true_on_valid_url(address):
     assert url(address)
@@ -118,6 +142,27 @@ def test_returns_true_on_valid_public_url(address, public):
     'http://.www.foo.bar./',
     'http://127.12.0.260',
     'http://example.com/">user@example.com',
+    'xn--mgbh0fb.xn--kgbechtv',
+    'http://xn--mgbh0fb',
+    'http://xn--mgbh0fb.xn---kgbechtv',
+    'http://xn---mgbh0fb.xn--kgbechtv',
+    'http://xn--mgbh0fb.xnk--gbechtv',
+    'http://xnm--gbh0fb.xn--kgbechtv',
+    'http:// xn--mgbh0fb.xn--kgbechtv',
+    ':// xn--mgbh0fb.xn--kgbechtv',
+    'http://-xn--mgbh0fb.xn--kgbechtv',
+    'http://xn--mgbh0fb-.xn--kgbechtv',
+    'http://xn--mgbh0fb.-xn--kgbechtv',
+    'http://xn--mgbh0fb.xn--kgbechtv-',
+    'http://x-n--mgbh0fb.xn--kgbechtv',
+    'http://xn--mgbh0fb.x-n--kgbechtv',
+    'http://xn--mgbh0fb.xn--kgbechtv./',
+    'http://xn--mgbh0fb..xn--kgbechtv',
+    'http:///xn--mgbh0fb.xn--kgbechtv',
+    'ttp://xn--mgbh0fb.xn--kgbechtv',
+    'http://xn--mgbh0fb.xn--kgbechtv/">user@example.com',
+    u'http://xn--mgbh0fb.إختبار',
+    u'http://مثال.xn--kgbechtv',
 ])
 def test_returns_failed_validation_on_invalid_url(address):
     assert isinstance(url(address), ValidationFailure)

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -14,4 +14,4 @@ from .url import url  # noqa
 from .utils import ValidationFailure, validator  # noqa
 from .uuid import uuid  # noqa
 
-__version__ = '0.12.3-nullripper'
+__version__ = '0.12.1337'

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -14,4 +14,4 @@ from .url import url  # noqa
 from .utils import ValidationFailure, validator  # noqa
 from .uuid import uuid  # noqa
 
-__version__ = '0.12.1'
+__version__ = '0.12.3-nullripper'

--- a/validators/domain.py
+++ b/validators/domain.py
@@ -5,7 +5,7 @@ from .utils import validator
 pattern = re.compile(
     r'^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|'  # domain pt.1
     r'([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|'  # domain pt.2
-    r'([a-zA-Z0-9][-_.a-zA-Z0-9]{0,61}[a-zA-Z0-9]))\.'  # domain pt.3
+    r'([a-zA-Z0-9][-_.a-zA-Z0-9]{0,61}[a-zA-Z0-9])){1,999}\.'  # domain pt.3
     r'([a-zA-Z]{2,13}|(xn--[a-zA-Z0-9]{2,30}))$'  # TLD
 )
 

--- a/validators/url.py
+++ b/validators/url.py
@@ -56,6 +56,9 @@ regex_idna_converter = re.compile(
     u"^"
     # protocol group
     u"(?P<protocol>" + protocol_identifier + u")"
+    # user:pass group
+    u"(?P<userpass>(?:[-a-z\u00a1-\uffff0-9._~%!$&'()*+,;=:]+"
+    u"(?::[-a-z0-9._~%!$&'()*+,;=:]*)?@)?)"
     # fqdn group: intentionally loose, only meant to isolate any
     # potential fqdn so that idna decoding can be attempted. 
     u"(?P<fqdn>[^/:]+)"
@@ -133,6 +136,7 @@ def url(value, public=False):
             #reassemble the URL after decoding the fqdn as idna
             idna_value = u"{protocol}{fqdn}{port}{resource}".format(
                 protocol=idna_dict['protocol'],
+                userpass = idna_dict['userpass'] or "",
                 fqdn=idna_dict['fqdn'].decode('idna'),
                 port=idna_dict['port'] or "",
                 resource=idna_dict['resource'] or ""

--- a/validators/url.py
+++ b/validators/url.py
@@ -60,7 +60,7 @@ regex_idna_converter = re.compile(
     u"(?P<userpass>(?:[-a-z\u00a1-\uffff0-9._~%!$&'()*+,;=:]+"
     u"(?::[-a-z0-9._~%!$&'()*+,;=:]*)?@)?)"
     # fqdn group: intentionally loose, only meant to isolate any
-    # potential fqdn so that idna decoding can be attempted. 
+    # potential fqdn so that idna decoding can be attempted.
     u"(?P<fqdn>[^/:]+)"
     # port number group
     u"(?P<port>:\d{2,5})?"
@@ -72,6 +72,7 @@ regex_idna_converter = re.compile(
 
 pattern = re.compile(regex)
 pattern_idna_converter = re.compile(regex_idna_converter)
+
 
 @validator
 def url(value, public=False):
@@ -127,23 +128,23 @@ def url(value, public=False):
     """
     result = pattern.match(value)
 
-    #if initial match failed, attempt an idna conversion
+    # if initial match failed, attempt an idna conversion
     if not result:
         try:
-            #use regex to separate the potential idna fqdn
+            # use regex to separate the potential idna fqdn
             idna_result = pattern_idna_converter.match(value)
             idna_dict = idna_result.groupdict()
-            #reassemble the URL after decoding the fqdn as idna
+            # reassemble the URL after decoding the fqdn as idna
             idna_value = u"{protocol}{fqdn}{port}{resource}".format(
                 protocol=idna_dict['protocol'],
-                userpass = idna_dict['userpass'] or "",
+                userpass=idna_dict['userpass'] or "",
                 fqdn=idna_dict['fqdn'].decode('idna'),
                 port=idna_dict['port'] or "",
                 resource=idna_dict['resource'] or ""
             )
             result = pattern.match(idna_value)
-        #if pattern doesn't match or host can't decode as idna then pass
-        except (AttributeError,UnicodeError):
+        # if pattern doesn't match or host can't decode as idna then pass
+        except (AttributeError, UnicodeError):
             pass
 
     if not public:


### PR DESCRIPTION
PR to resolve issue #78. In short, my changes make it so that URLs containing IDNA A-labels (e.g. "http://xn--j1ail.xn--p1ai") will pass validation instead of failing. Please refer to the issue for a more comprehensive explanation of the problem and my proposed solution.