### PR TITLE
Include use_2to3 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     description='Python Data Validation for Humans™.',
     long_description=__doc__,
     packages=find_packages('.', exclude=['tests', 'tests.*']),
+    use_2to3=True,
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
This allows installing from Github on a Python 3 project with pip.