### PR TITLE
Add ipv4_strict - don't allow leading 0 in octects

### DIFF
--- a/tests/test_ipv4_strict.py
+++ b/tests/test_ipv4_strict.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from validators import ipv4, ipv4_strict, ipv6, ValidationFailure
+
+
+@pytest.mark.parametrize(('address',), [
+    ('127.0.0.1',),
+    ('123.5.77.88',),
+    ('12.12.12.12',),
+])
+def test_returns_true_on_valid_ipv4_address(address):
+    assert ipv4_strict(address)
+    assert not ipv6(address)
+
+
+@pytest.mark.parametrize(('address',), [
+    ('abc.0.0.1',),
+    ('1278.0.0.1',),
+    ('127.0.0.abc',),
+    ('900.200.100.75',),
+    ('100.100.033.033',),
+])
+def test_returns_failed_validation_on_invalid_ipv4_address(address):
+    assert isinstance(ipv4_strict(address), ValidationFailure)

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -15,7 +15,7 @@ from .extremes import Max, Min
 from .hashes import md5, sha1, sha224, sha256, sha512
 from .i18n import fi_business_id, fi_ssn
 from .iban import iban
-from .ip_address import ipv4, ipv4_cidr, ipv6, ipv6_cidr
+from .ip_address import ipv4, ipv4_cidr, ipv4_strict, ipv6, ipv6_cidr
 from .length import length
 from .mac_address import mac_address
 from .slug import slug
@@ -26,7 +26,7 @@ from .uuid import uuid
 
 __all__ = ('between', 'domain', 'email', 'Max', 'Min', 'md5', 'sha1', 'sha224',
            'sha256', 'sha512', 'fi_business_id', 'fi_ssn', 'iban', 'ipv4',
-           'ipv4_cidr', 'ipv6', 'ipv6_cidr', 'length', 'mac_address', 'slug',
+           'ipv4_cidr', 'ipv6', 'ipv6_cidr', 'ipv4_strict', 'length', 'mac_address', 'slug',
            'truthy', 'url', 'ValidationFailure', 'validator', 'uuid',
            'card_number', 'visa', 'mastercard', 'amex', 'unionpay', 'diners',
            'jcb', 'discover')

--- a/validators/ip_address.py
+++ b/validators/ip_address.py
@@ -28,6 +28,29 @@ def ipv4(value):
         return False
     return all(0 <= int(part) < 256 for part in groups)
 
+@validator
+def ipv4_strict(value):
+    """Essentulaally the same as ipv4 
+    Returns whether or not given value is valid IP version 4 addresses
+    but doesn't all leading zero's in octets
+    
+    Examples:
+    
+       >>> ipv4_strict('100.100.33.33')
+       True
+     
+       >> ipv4_strict('100.100.0.33.0.33')
+       ValidationFailure(func=ibv4_strict, args={''value':'100.100.033.0.33'})
+
+    ..versionadded::0.1
+    
+    :param value: IP address string to validate
+    """
+    octects = value.split('.')
+    for octect in octects:
+        if '0' == octect[0] and len(octect) > 1:
+            return False
+    return ipv4(value)
 
 @validator
 def ipv4_cidr(value):


### PR DESCRIPTION
I needed this for one of my apps so I thought I would take a crack at it.