### PR TITLE
Updated domain validator coverage

### DIFF
--- a/validators/domain.py
+++ b/validators/domain.py
@@ -11,7 +11,7 @@ else:
     text_type = unicode
 
 pattern = re.compile(
-    r'^(?:[a-zA-Z0-9]'  # First character of the domain
+    r'^(?:[a-zA-Z0-9_]'  # First character of the domain
     r'(?:[a-zA-Z0-9-_]{0,61}[A-Za-z0-9])?\.)'  # Sub domain + hostname
     r'+[A-Za-z0-9][A-Za-z0-9-_]{0,61}'  # First 61 characters of the gTLD
     r'[A-Za-z]$'  # Last character of the gTLD


### PR DESCRIPTION
Updated domain validator to support domains that start with an underscore. These domains are quite common in the wild.

For example:
_jabber._tcp.gmail.com
_sip._udp.apnic.net

See RFC 2181, section 11, "Name syntax" and RFC 1034, section 3.5 "Preferred name syntax" for more info.