### PR TITLE
Add new Finnish social security number punctuation marks

### DIFF
--- a/tests/i18n/test_fi.py
+++ b/tests/i18n/test_fi.py
@@ -31,6 +31,8 @@ def test_returns_failed_validation_on_invalid_business_id(value):
     ('010101+0101',),
     ('010101A0101',),
     ('010190-900P',),
+    ('020516C903K',),
+    ('010594Y9032',),
 ])
 def test_returns_true_on_valid_ssn(value):
     assert fi_ssn(value)

--- a/validators/i18n/fi.py
+++ b/validators/i18n/fi.py
@@ -9,7 +9,7 @@ ssn_pattern = re.compile(
     (?P<date>(0[1-9]|[1-2]\d|3[01])
     (0[1-9]|1[012])
     (\d{{2}}))
-    [A+-]
+    [ABCDEFYXWVU+-]
     (?P<serial>(\d{{3}}))
     (?P<checksum>[{checkmarks}])$""".format(checkmarks=ssn_checkmarks),
     re.VERBOSE


### PR DESCRIPTION
B, C, D, E, F, Y, X, W, V, and U are valid punctuation marks starting 2023-01-01
See: https://dvv.fi/en/reform-of-personal-identity-code