### PR TITLE
#197 fixed double-quote 

### DIFF
--- a/validators/email.py
+++ b/validators/email.py
@@ -16,7 +16,7 @@ domain_regex = re.compile(
     r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+'
     r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?$)'
     # literal form, ipv4 address (SMTP 4.1.3)
-    r'|^\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)'
+    r'^\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)'
     r'(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$',
     re.IGNORECASE)
 domain_whitelist = ['localhost']


### PR DESCRIPTION
fixed Email with double-quote and and comma at end considered "valid"