### PR TITLE
maint: improves `domain` module

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,42 +1,56 @@
+"""Test Domain."""
 # -*- coding: utf-8 -*-
+
+# standard
 import pytest
 
+# local
 from validators import domain, ValidationFailure
 
 
-@pytest.mark.parametrize('value', [
-    'example.com',
-    'xn----gtbspbbmkef.xn--p1ai',
-    'underscore_subdomain.example.com',
-    'something.versicherung',
-    'someThing.versicherung',
-    '11.com',
-    '3.cn',
-    'a.cn',
-    'sub1.sub2.sample.co.uk',
-    'somerandomexample.xn--fiqs8s',
-    'kräuter.com',
-    'über.com'
-])
-def test_returns_true_on_valid_domain(value):
-    assert domain(value)
+@pytest.mark.parametrize(
+    ("value", "rfc_1034", "rfc_2782"),
+    [
+        ("example.com", False, False),
+        ("xn----gtbspbbmkef.xn--p1ai", False, False),
+        ("underscore_subdomain.example.com", False, False),
+        ("something.versicherung", False, False),
+        ("someThing.versicherung.", True, False),
+        ("11.com", False, False),
+        ("3.cn.", True, False),
+        ("_example.com", False, True),
+        ("a.cn", False, False),
+        ("sub1.sub2.sample.co.uk", False, False),
+        ("somerandomexample.xn--fiqs8s", False, False),
+        ("kräuter.com.", True, False),
+        ("über.com", False, False),
+    ],
+)
+def test_returns_true_on_valid_domain(value: str, rfc_1034: bool, rfc_2782: bool):
+    """Test returns true on valid domain."""
+    assert domain(value, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
 
 
-@pytest.mark.parametrize('value', [
-    'example.com/',
-    'example.com:4444',
-    'example.-com',
-    'example.',
-    '-example.com',
-    'example-.com',
-    '_example.com',
-    'example_.com',
-    'example',
-    'a......b.com',
-    'a.123',
-    '123.123',
-    '123.123.123',
-    '123.123.123.123'
-])
-def test_returns_failed_validation_on_invalid_domain(value):
-    assert isinstance(domain(value), ValidationFailure)
+@pytest.mark.parametrize(
+    ("value", "rfc_1034", "rfc_2782"),
+    [
+        ("example.com/.", True, False),
+        ("example.com:4444", False, False),
+        ("example.-com", False, False),
+        ("example.", False, False),
+        ("-example.com", False, False),
+        ("example-.com.", True, False),
+        ("_example.com", False, False),
+        ("_example._com", False, False),
+        ("example_.com", False, False),
+        ("example", False, False),
+        ("a......b.com", False, False),
+        ("a.123", False, False),
+        ("123.123", False, False),
+        ("123.123.123.", True, False),
+        ("123.123.123.123", False, False),
+    ],
+)
+def test_returns_failed_validation_on_invalid_domain(value: str, rfc_1034: bool, rfc_2782: bool):
+    """Test returns failed validation on invalid domain."""
+    assert isinstance(domain(value, rfc_1034=rfc_1034, rfc_2782=rfc_2782), ValidationFailure)


### PR DESCRIPTION
maint: improves `domain` module

- Uses type hints, improve docs
- Regards [RFC 1034](https://www.rfc-editor.org/rfc/rfc1034) and [RFC 2782](https://www.rfc-editor.org/rfc/rfc2782)
- Updates corresponding test functions

**Related items**

*Issues*

- Closes #52
- Closes #74
- Closes #81
- Closes #89
- Closes #95
- Closes #120
- Closes #124
- Closes #141
- Closes #143
- Closes #199
- Closes #204

*PRs*

- Closes #114
- Closes #179