### PR TITLE
maint: update `email` module

### DIFF
--- a/validators/domain.py
+++ b/validators/domain.py
@@ -1,4 +1,5 @@
 """Domain."""
+# -*- coding: utf-8 -*-
 
 # standard
 import re

--- a/validators/ip_address.py
+++ b/validators/ip_address.py
@@ -1,4 +1,5 @@
 """IP Address."""
+# -*- coding: utf-8 -*-
 
 # standard
 from ipaddress import (

--- a/validators/uuid.py
+++ b/validators/uuid.py
@@ -1,4 +1,5 @@
 """UUID."""
+# -*- coding: utf-8 -*-
 
 # standard
 from typing import Union


### PR DESCRIPTION
- email's domain part is now compliant to [RFC 5321](https://www.rfc-editor.org/rfc/rfc5321)
- it can also accept simple hostname (like `localhost`)
- fix missing `utf-8` comments

**Related Items**

*Issues*

- Closes #108
- Closes #142