### PR TITLE
Fix ReDoS (GHSL-2021-110)

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -134,6 +134,7 @@ def test_returns_true_on_valid_public_url(address, public):
     'http://[2010:836B:4179::836B:4179',
     'http://2010:836B:4179::836B:4179',
     'http://2010:836B:4179::836B:4179:80/index.html',
+    'http://0.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.', # ReDoS
 ])
 def test_returns_failed_validation_on_invalid_url(address):
     assert isinstance(url(address), ValidationFailure)

--- a/validators/url.py
+++ b/validators/url.py
@@ -70,10 +70,10 @@ regex = re.compile(  # noqa: W605
     r")\]|"
     # host name
     r"(?:(?:(?:xn--[-]{0,2})|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"
-    r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)"
+    r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9])"
     # domain name
     r"(?:\.(?:(?:xn--[-]{0,2})|[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]-?)*"
-    r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]+)*"
+    r"[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9])*"
     # TLD identifier
     r"(?:\.(?:(?:xn--[-]{0,2}[a-z\u00a1-\uffff\U00010000-\U0010ffff0-9]{2,})|"
     r"[a-z\u00a1-\uffff\U00010000-\U0010ffff]{2,}))"


### PR DESCRIPTION
Remove two `+` characters from the regex. They don't make any difference to the string that the regex can match, but they're causing a [ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS). I've also added a regression test for the ReDoS.