### PR TITLE
maint: improve `domain`, `email` & `hostname`

### DIFF
--- a/validators/domain.py
+++ b/validators/domain.py
@@ -45,7 +45,7 @@ def domain(value: str, /, *, rfc_1034: bool = False, rfc_2782: bool = False):
     > *New in version 0.9.0*.
     """
     try:
-        return not re.search(r"\s", value) and re.compile(
+        return not re.search(r"\s", value) and re.match(
             # First character of the domain
             rf"^(?:[a-zA-Z0-9{'_'if rfc_2782 else ''}]"
             # Sub domain + hostname
@@ -53,7 +53,9 @@ def domain(value: str, /, *, rfc_1034: bool = False, rfc_2782: bool = False):
             # First 61 characters of the gTLD
             + r"+[A-Za-z0-9][A-Za-z0-9-_]{0,61}"
             # Last character of the gTLD
-            + rf"[A-Za-z]{r'.$' if rfc_1034 else r'$'}"
-        ).match(value.encode("idna").decode("ascii"))
+            + rf"[A-Za-z]{r'.$' if rfc_1034 else r'$'}",
+            value.encode("idna").decode("utf-8"),
+            re.IGNORECASE,
+        )
     except UnicodeError:
         return False

--- a/validators/email.py
+++ b/validators/email.py
@@ -14,8 +14,9 @@ def email(
     value: str,
     /,
     *,
+    ipv6_address: bool = False,
+    ipv4_address: bool = False,
     simple_host: bool = False,
-    ip_address: bool = False,
     rfc_1034: bool = False,
     rfc_2782: bool = False,
 ):
@@ -38,10 +39,12 @@ def email(
     Args:
         value:
             eMail string to validate.
+        ipv6_address:
+            When the domain part is an IPv6 address.
+        ipv4_address:
+            When the domain part is an IPv4 address.
         simple_host:
             When the domain part is a simple hostname.
-        ip_address:
-            When the domain part is an IP address.
         rfc_1034:
             Allow trailing dot in domain name.
             Ref: [RFC 1034](https://www.rfc-editor.org/rfc/rfc1034).
@@ -66,7 +69,7 @@ def email(
         # ref: RFC 1034 and 5231
         return False
 
-    if ip_address:
+    if ipv6_address or ipv4_address:
         if domain_part.startswith("[") and domain_part.endswith("]"):
             # ref: RFC 5321
             domain_part = domain_part.lstrip("[").rstrip("]")
@@ -77,7 +80,8 @@ def email(
         bool(
             hostname(
                 domain_part,
-                skip_ip_addr=not ip_address,
+                skip_ipv6_addr=not ipv6_address,
+                skip_ipv4_addr=not ipv4_address,
                 may_have_port=False,
                 maybe_simple=simple_host,
                 rfc_1034=rfc_1034,

--- a/validators/hostname.py
+++ b/validators/hostname.py
@@ -46,8 +46,9 @@ def hostname(
     value: str,
     /,
     *,
+    skip_ipv6_addr: bool = False,
+    skip_ipv4_addr: bool = False,
     may_have_port: bool = True,
-    skip_ip_addr: bool = False,
     maybe_simple: bool = True,
     rfc_1034: bool = False,
     rfc_2782: bool = False,
@@ -79,10 +80,12 @@ def hostname(
     Args:
         value:
             Hostname string to validate.
+        skip_ipv6_addr:
+            When hostname string cannot be an IPv6 address.
+        skip_ipv4_addr:
+            When hostname string cannot be an IPv4 address.
         may_have_port:
             Hostname string may contain port number.
-        skip_ip_addr:
-            When hostname string cannot be an IP address.
         maybe_simple:
             Hostname string maybe only hyphens and alpha-numerals.
         rfc_1034:
@@ -104,13 +107,13 @@ def hostname(
         return (
             (_simple_hostname_regex().match(host_seg) if maybe_simple else False)
             or domain(host_seg, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
-            or (False if skip_ip_addr else ipv4(host_seg, cidr=False))
-            or (False if skip_ip_addr else ipv6(host_seg, cidr=False))
+            or (False if skip_ipv4_addr else ipv4(host_seg, cidr=False))
+            or (False if skip_ipv6_addr else ipv6(host_seg, cidr=False))
         )
 
     return (
         (_simple_hostname_regex().match(value) if maybe_simple else False)
         or domain(value, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
-        or (False if skip_ip_addr else ipv4(value, cidr=False))
-        or (False if skip_ip_addr else ipv6(value, cidr=False))
+        or (False if skip_ipv4_addr else ipv4(value, cidr=False))
+        or (False if skip_ipv6_addr else ipv6(value, cidr=False))
     )


### PR DESCRIPTION
- in `domain`: decode value to `utf-8` instead of `ascii`; use `re.match` directly
- in `email`: split `ip_address` to `ipv4` and `ipv6` parameters
- in `hostname`: split `skip_ip_addr` to skip `ipv4` & `ipv6` parameters

> This PR will be closed in an hour.