### PR TITLE
maint: misc changes to dev and ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,51 +8,32 @@ on:
     branches: [master]
 
 jobs:
-  DevOps:
+  PreflightChecks:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
+      # checkout repository
       - name: Checkout repository
         uses: actions/checkout@v3
+      # setup specific python version
       - name: Setup Python v${{ matrix.python-version }}
-        # id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #          install & configure poetry
-      #----------------------------------------------
+      # install & configure poetry
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.3.2
+          version: 1.4.1
           virtualenvs-create: true
           virtualenvs-in-project: true
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      # - name: Load cached venv
-      #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: .venv
-      #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install test dependencies
-        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --no-ansi --only tests
-      #----------------------------------------------
-      #              run test suite
-      #----------------------------------------------
-      - name: Run tests
+      # install dependencies
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-ansi --without docs,hooks,sast
+      # run preflight checks
+      - name: Preflight checks with tox
         run: |
           source .venv/bin/activate
-          pytest tests/
+          tox

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,21 +29,21 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.3.2
+          version: 1.4.1
           virtualenvs-create: true
           virtualenvs-in-project: true
-      - name: Install docs dependencies
+      - name: Install dependencies
         run: poetry install --no-interaction --no-root --no-ansi --only docs
       - name: Build documentation
         run: |
           source .venv/bin/activate
-          python ./docs/gen_docs.py
+          python docs/gen_docs.py
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - name: Upload artifact
+      - name: Upload artifacts
         uses: actions/upload-pages-artifact@v1
         with:
-          path: "./site/"
+          path: "site/"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/docs/gen_docs.py
+++ b/docs/gen_docs.py
@@ -1,4 +1,5 @@
 """Generate docs."""
+# -*- coding: utf-8 -*-
 
 # standard
 from shutil import rmtree, move, copy

--- a/poetry.lock
+++ b/poetry.lock
@@ -1454,4 +1454,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "50370d78d455974d8323b523c02050900a5570ce08657757a1666a03c92fdca1"
+content-hash = "e3a0342f99c520ad93ac5eec5971905eb4bd4bd9efa99cdc67f9bcb65ff9d83b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ include = ["CHANGES.md", "docs/*"]
 python = "^3.8"
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^3.2.0"
 tox = "^4.4.7"
 
 [tool.poetry.group.docs.dependencies]
@@ -36,6 +35,9 @@ mkdocs = "^1.4.2"
 mkdocs-material = "^9.1.3"
 mkdocstrings = { extras = ["python"], version = "^0.20.0" }
 pyaml = "^21.10.1"
+
+[tool.poetry.group.hooks.dependencies]
+pre-commit = "^3.2.0"
 
 [tool.poetry.group.sast.dependencies]
 bandit = "^1.7.5"
@@ -71,7 +73,9 @@ ensure_newline_before_comments = true
 extend_skip_glob = ["**/i18n/*"]
 force_grid_wrap = 0
 force_sort_within_sections = true
-ignore_comments = true
+import_heading_stdlib = "standard"
+import_heading_thirdparty = "external"
+import_heading_localfolder = "local"
 include_trailing_comma = true
 known_local_folder = ["validators"]
 length_sort = true
@@ -92,36 +96,39 @@ typeCheckingMode = "strict"
 
 [tool.tox]
 legacy_tox_ini = """
-    [tox]
-    requires =
-        tox >= 4.0
-    env_list = py{38,39,310,311}
-        fmt_black, fmt_isort, lint, type
+[tox]
+min_version = 4.0
+env_list =
+    py{38,39,310,311}
+    fmt_black
+    fmt_isort
+    lint
+    type
 
-    [testenv]
-    description = run unit tests
-    deps = pytest
-    commands = pytest
+[testenv]
+description = run unit tests
+deps = pytest
+commands = pytest tests/
 
-    [testenv:fmt_black]
-    description = run formatter
-    deps = black
-    commands = black .
+[testenv:fmt_black]
+description = run formatter
+deps = black
+commands = black .
 
-    [testenv:fmt_isort]
-    description = run formatter
-    deps = isort
-    commands = isort .
+[testenv:fmt_isort]
+description = run formatter
+deps = isort
+commands = isort .
 
-    [testenv:lint]
-    description = run linters
-    deps = flake8
-    commands = flake8
+[testenv:lint]
+description = run linters
+deps = flake8
+commands = flake8
 
-    [testenv:type]
-    description = run type checker
-    deps =
-        pyright
-        pytest
-    commands = pyright
+[testenv:type]
+description = run type checker
+deps =
+    pyright
+    pytest
+commands = pyright
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 
 [flake8]
 docstring-convention = google
-exclude = __pycache__,.github,.pytest_cache,.tox,.vscode,site,i18n
+exclude = __pycache__,.github,.pytest_cache,.tox,.venv,.vscode,site,i18n
 max-line-length = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,4 @@
 """Tests."""
+# -*- coding: utf-8 -*-
+
+# isort: skip_file

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -1,22 +1,29 @@
 """Validate Anything!"""
 # -*- coding: utf-8 -*-
 
-from .card import card_number, mastercard, unionpay, discover, diners, visa, amex, jcb
-from .hashes import sha512, sha256, sha224, sha1, md5
-from .utils import validator, ValidationFailure
-from .i18n import fi_business_id, fi_ssn
-from .mac_address import mac_address
-from .btc_address import btc_address
-from .ip_address import ipv6, ipv4
-from .hostname import hostname
+# isort: skip_file
+
+# The following imports are sorted alphabetically, manually.
+# Each line is grouped based first or type, then sorted alphabetically.
+# This is for the reference documentation.
+
+# local
 from .between import between
-from .length import length
+from .btc_address import btc_address
+from .card import amex, card_number, diners, discover, jcb, mastercard, unionpay, visa
 from .domain import domain
 from .email import email
-from .uuid import uuid
-from .slug import slug
+from .hashes import md5, sha1, sha224, sha256, sha512
+from .hostname import hostname
+from .i18n import fi_business_id, fi_ssn
 from .iban import iban
+from .ip_address import ipv4, ipv6
+from .length import length
+from .mac_address import mac_address
+from .slug import slug
 from .url import url
+from .utils import validator, ValidationFailure
+from .uuid import uuid
 
 __all__ = (
     "amex",


### PR DESCRIPTION
- moves `pre-commit` to `hooks` group
- uses `isort` to add grouping comments, instead of ignoring them
- `__init__.py` is ignored by `isort` for documentation
- fix missing `-*- coding: utf-8 -*-` annotations
- update `tox` configuration in `pyproject.toml`
- in GitHub actions, `main.yml`:
	- changed CI job name to `PreflightChecks`
	- updated poetry version to `1.4.1`
	- runs `tox` with strategy-matrix
- in `pages.yml`:
	- updated poetry version to `1.4.1`
	- fix typos
- makes flake8 ignore `.venv`

> This PR will be closed in an hour.