### PR TITLE
fix: url validator considers urls with /#/ as valid

### DIFF
--- a/src/validators/url.py
+++ b/src/validators/url.py
@@ -116,6 +116,7 @@ def _validate_optionals(path: str, query: str, fragment: str):
     if query:
         optional_segments &= bool(_query_regex().match(query))
     if fragment:
+        fragment = fragment.lstrip("/") if fragment.startswith("/") else fragment
         optional_segments &= all(char_to_avoid not in fragment for char_to_avoid in ("/", "?"))
     return optional_segments
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -84,6 +84,7 @@ from validators import ValidationError, url
         "https://travel-usa.com/wisconsin/旅行/",
         "http://:::::::::::::@exmp.com",
         "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+        "https://exchange.jetswap.finance/#/swap",
         # when simple_host=True
         # "http://localhost",
         # "http://localhost:8000",


### PR DESCRIPTION
Attempts to resolve https://github.com/python-validators/validators/issues/288 thanks to @joe733 's recommandation