### PR TITLE
Add note about ValidationFailure to ValidationError in changes.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### What's Changed
 
 - feat: refactoring; updates; fixes; bump version by @joe733 in [#283](https://github.com/python-validators/validators/pull/283)
+  * BC break: ValidationFailure renamed to ValidationError,
 - build(deps): bump pymdown-extensions from 9.11 to 10.0 by @dependabot in [#273](https://github.com/python-validators/validators/pull/273)
 - build(deps): bump requests from 2.28.2 to 2.31.0 by @dependabot in [#275](https://github.com/python-validators/validators/pull/275)
 - add validator ETH addresses (ERC20) by @msamsami in [#276](https://github.com/python-validators/validators/pull/276)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@
 ### What's Changed
 
 - feat: refactoring; updates; fixes; bump version by @joe733 in [#283](https://github.com/python-validators/validators/pull/283)
-  * BC break: ValidationFailure renamed to ValidationError,
+- *Breaking Changes*:
+  - `ValidationFailure` renamed to `ValidationError` in [joe733@12ae1f5](https://github.com/joe733/pyvalidators/commit/12ae1f5850555d11e1f1a2c03f597fd10610215a)
 - build(deps): bump pymdown-extensions from 9.11 to 10.0 by @dependabot in [#273](https://github.com/python-validators/validators/pull/273)
 - build(deps): bump requests from 2.28.2 to 2.31.0 by @dependabot in [#275](https://github.com/python-validators/validators/pull/275)
 - add validator ETH addresses (ERC20) by @msamsami in [#276](https://github.com/python-validators/validators/pull/276)


### PR DESCRIPTION
0.21.1 to 0.21.2 contained a breaking change when renaming ValidationFailure to ValidationError
The pr that did this: https://github.com/python-validators/validators/pull/283
And the full changelog: https://github.com/python-validators/validators/compare/0.21.1...0.21.2
This change is not reflected in CHANGES.md which makes it hard for others to see this change.

This PR adds the information to the CHANGES.md file.