### PR TITLE
patch: `domain` & `url` modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,19 +147,21 @@ _**Breaking**_ ⚠️
 - `extremes.py` renamed to `_extremes.py` and is no longer exposed.
 - `truthy` was discarded in favour of simple `bool()` function.
 - `ipv4_cidr()` and `ipv6_cidr()` has been dropped in favour of `cidr: bool = True` and `cidr: bool = True` keyword-only parameters.
-- `email` API now accepts the following keyword-only arguments:
+- `email()` API now accepts the following keyword-only arguments:
   - `simple_host: bool = False`,
   - `ipv6_address: bool = False`,
   - `ipv4_address: bool = False`,
   - `rfc_1034: bool = False` and
   - `rfc_2782: bool = False`.
-- `url` has been refactored, it accepts the following keyword-only arguments:
+- `whitelist=None` has been removed from `email()`.
+- `url()` has been refactored, it accepts the following keyword-only arguments:
   - `skip_ipv6_addr: bool = False`,
   - `skip_ipv4_addr: bool = False`,
   - `may_have_port: bool = True`,
   - `simple_host: bool = False`,
   - `rfc_1034: bool = False` and
   - `rfc_2782: bool = False`.
+- `public=False` keyword argument has been removed from `url()`.
 - Exposes `i18n` functions directly via `__init__.py`.
 - `@validator` decorator catches `Exception`.
 

--- a/src/validators/domain.py
+++ b/src/validators/domain.py
@@ -42,7 +42,7 @@ def domain(value: str, /, *, rfc_1034: bool = False, rfc_2782: bool = False):
             # First character of the domain
             rf"^(?:[a-zA-Z0-9{'_'if rfc_2782 else ''}]"
             # Sub domain + hostname
-            + r"(?:[a-zA-Z0-9-_]{0,61}[A-Za-z0-9])?\.)"
+            + rf"(?:[a-zA-Z0-9-_]{{0,61}}[A-Za-z0-9{'_'if rfc_2782 else ''}])?\.)"
             # First 61 characters of the gTLD
             + r"+[A-Za-z0-9][A-Za-z0-9-_]{0,61}"
             # Last character of the gTLD

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -18,6 +18,7 @@ from validators import ValidationError, domain
         ("11.com", False, False),
         ("3.cn.", True, False),
         ("_example.com", False, True),
+        ("example_.com", False, True),
         ("a.cn", False, False),
         ("sub1.sub2.sample.co.uk", False, False),
         ("somerandomexample.xn--fiqs8s", False, False),

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -152,6 +152,7 @@ def test_returns_true_on_valid_url(value: str):
         "http://[2010:836B:4179::836B:4179",
         "http://2010:836B:4179::836B:4179",
         "http://2010:836B:4179::836B:4179:80/index.html",
+        "https://example.org?q=search');alert(document.domain);",
         "https://www.example.com/foo/?bar=baz&inga=42&quux",
         "https://foo.com/img/bar/baz.jpg?-62169987208",
         "https://foo.bar.net/baz.php?-/inga/test-lenient-query/",


### PR DESCRIPTION
- `domain` allows trailing underscore under the pretense of rfc 2782
- adds separator based query parsing
- changelog includes what parameters were removed causing incompatibly

**Related Items**

_Issues_

- Closes #315
- Closes #327
- Closes #338