### PR TITLE
fix(uri): replace `lstrip("mailto:")` with manual prefix removal

### DIFF
--- a/src/validators/uri.py
+++ b/src/validators/uri.py
@@ -68,7 +68,7 @@ def uri(value: str, /):
 
     # email
     if value.startswith("mailto:"):
-        return email(value.lstrip("mailto:"))
+        return email(value[len("mailto:"):])
 
     # file
     if value.startswith("file:"):


### PR DESCRIPTION
The use of `lstrip()` here was a bit too aggressive.
For example:
```
In [1]: "mailto:maximilian.moser@tuwien.ac.at".lstrip("mailto:")
Out[1]: 'ximilian.moser@tuwien.ac.at'
```
But:
```
In [2]: "mailto:maximilian.moser@tuwien.ac.at".removeprefix("mailto:")
Out[2]: 'maximilian.moser@tuwien.ac.at'
```