### PR TITLE
fix: reject MAC addresses with mixed separators

### DIFF
--- a/src/validators/mac_address.py
+++ b/src/validators/mac_address.py
@@ -29,4 +29,8 @@ def mac_address(value: str, /):
         (Literal[True]): If `value` is a valid MAC address.
         (ValidationError): If `value` is an invalid MAC address.
     """
+    # Check for mixed separators: MAC addresses cannot use both ':' and '-' simultaneously
+    if ":" in value and "-" in value:
+        return False
+
     return re.match(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$", value) if value else False


### PR DESCRIPTION
Previously, the MAC address validator would accept invalid MAC addresses that mixed different separators, such as `aa:bb-cc-dd:ee:ff`, but a valid MAC address should use consistent separators throughout.

This PR improves the MAC address validator by adding a check to reject MAC addresses that use mixed separators (both `:` and `-` characters).
