### PR TITLE
fix hostname accepting values longer than 253 chars when they contain dots

### DIFF
--- a/src/validators/hostname.py
+++ b/src/validators/hostname.py
@@ -114,12 +114,17 @@ def hostname(
         return False
 
     if may_have_port and (host_seg := _port_validator(value)):
+        if len(host_seg) > 253:
+            return False
         return (
             (_simple_hostname_regex().match(host_seg) if maybe_simple else False)
             or domain(host_seg, consider_tld=consider_tld, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
             or (False if skip_ipv4_addr else ipv4(host_seg, cidr=False, private=private))
             or (False if skip_ipv6_addr else ipv6(host_seg, cidr=False))
         )
+
+    if len(value) > 253:
+        return False
 
     return (
         (_simple_hostname_regex().match(value) if maybe_simple else False)

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -40,6 +40,16 @@ def test_returns_true_on_valid_hostname(value: str, rfc_1034: bool, rfc_2782: bo
 @pytest.mark.parametrize(
     ("value", "rfc_1034", "rfc_2782"),
     [
+        # bad (hostname exceeding 253 chars)
+        (
+            "kld8MXQh6YalMqKRbfs895gMjW5T4p2EwToPoCSThPHHbXgmXc."
+            "kld8MXQh6YalMqKRbfs895gMjW5T4p2EwToPoCSThPHHbXgmXc."
+            "kld8MXQh6YalMqKRbfs895gMjW5T4p2EwToPoCSThPHHbXgmXc."
+            "kld8MXQh6YalMqKRbfs895gMjW5T4p2EwToPoCSThPHHbXgmXc."
+            "kld8MXQh6YalMqKRbfs895gMjW5T4p2EwToPoCSThPHHbXgmXcab",
+            False,
+            False,
+        ),
         # bad (simple hostname w/ optional ports)
         ("ubuntu-pc:443080", False, False),
         ("this-pc-is-sh*t", False, False),


### PR DESCRIPTION
Fixes #413

The hostname validator was only checking individual label lengths via the simple hostname regex but had no overall length limit on the full value. Hostnames with dots where each label was under 63 chars but the total length exceeded 253 would incorrectly pass validation.

Added a 253 character length check on the host segment (both with and without a port suffix) per RFC 1123. Also added a test case using the exact example from the issue.