### PR TITLE
feat(uri): add telnet URI validation per RFC 4248 (#388) 

### DIFF
--- a/src/validators/uri.py
+++ b/src/validators/uri.py
@@ -3,8 +3,12 @@
 # Read: https://stackoverflow.com/questions/176264
 # https://www.rfc-editor.org/rfc/rfc3986#section-3
 
+# standard
+from urllib.parse import urlsplit
+
 # local
 from .email import email
+from .hostname import hostname
 from .url import url
 from .utils import validator
 
@@ -19,6 +23,46 @@ def _ipfs_url(value: str):
     if not value.startswith("ipfs://"):
         return False
     return True
+
+
+def _telnet_url(value: str):
+    """Validate a telnet URL per RFC 4248.
+
+    Ref: https://www.rfc-editor.org/rfc/rfc4248"
+    Examples:
+    >>> _telnet_url('telnet://example.com')
+    True
+    >>> _telnet_url('telnet://example.com:23')
+    True
+    >>> _telnet_url('telnet://example.com:23/')
+    True
+
+    Args:
+        value:
+            Telnet URL to validate.
+
+    Returns:
+        (Literal[True]): If `value` is a Telnet URI.
+        (ValidationError): If `value` is an invalid URI.
+    """
+    try:
+        scheme, netloc, path, query, fragment = urlsplit(value)
+    except ValueError:
+        return False
+
+    if scheme != "telnet":
+        return False
+    if not netloc:
+        return False
+    if query or fragment:
+        return False
+    if path and path != "/":
+        return False
+
+    # handling any additional checks user/pass
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[1]
+    return hostname(netloc, may_have_port=True)
 
 
 @validator
@@ -60,7 +104,6 @@ def uri(value: str, /):
             "rtsp",
             "sftp",
             "ssh",
-            "telnet",
         }
         # fmt: on
     ):
@@ -97,5 +140,9 @@ def uri(value: str, /):
     # urc
     if value.startswith("urc:"):
         return True
+
+    # telnet
+    if value.startswith("telnet:"):
+        return _telnet_url(value)
 
     return False

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,0 +1,39 @@
+"""Test URI."""
+
+# external
+import pytest
+
+# local
+from validators.uri import uri
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "telnet://example.com",
+        "telnet://example.com/",
+        "telnet://example.com:23",
+        "telnet://example.com:23/",
+        "telnet://192.168.1.1",
+        "telnet://192.168.1.1:23",
+        "telnet://user:password@example.com",
+        "telnet://user:password@example.com:23/",
+    ],
+)
+def test_valid_telnet_uri(value: str):
+    """Test valid telnet URI."""
+    assert uri(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "telnet://",
+        "telnet://example.com/path",
+        "telnet://example.com?query=1",
+        "telnet://example.com#frag",
+    ],
+)
+def test_invalid_telnet_uri(value: str):
+    """Test invalid telnet URI."""
+    assert not uri(value)


### PR DESCRIPTION
## Summary  
- Add `_telnet_url()` helper function to validate telnet URIs per RFC 4248           
- Route `telnet:` scheme to dedicated validator instead of generic `url()`           
- Telnet URI format: `telnet://<user>:<password>@<host>:<port>/`  [ref: telnet](https://www.rfc-editor.org/rfc/rfc4248)         
- Add tests for valid and invalid telnet URIs               
## Related
  Closes #388                                                                          
  
  ## Test plan
  - [x] `ruff format` passes
  - [x] `ruff check` passes
  - [x] `pytest` passes (965 tests)
  - [x] `bandit` passes (no security issues)