### PR TITLE
 Correct private IP range classification by removing flawed custom logic

### DIFF
--- a/src/validators/ip_address.py
+++ b/src/validators/ip_address.py
@@ -9,33 +9,10 @@ from ipaddress import (
     IPv6Network,
     NetmaskValueError,
 )
-import re
 from typing import Optional
 
 # local
 from .utils import validator
-
-
-def _check_private_ip(value: str, is_private: Optional[bool]):
-    if is_private is None:
-        return True
-    if (
-        any(
-            value.startswith(l_bit)
-            for l_bit in {
-                "10.",  # private
-                "192.168.",  # private
-                "169.254.",  # link-local
-                "127.",  # localhost
-                "0.0.0.0",  # loopback #nosec
-            }
-        )
-        or re.match(r"^172\.(?:1[6-9]|2\d|3[0-1])\.", value)  # private
-        or re.match(r"^(?:22[4-9]|23[0-9]|24[0-9]|25[0-5])\.", value)  # broadcast
-    ):
-        return is_private
-
-    return not is_private
 
 
 @validator
@@ -72,7 +49,7 @@ def ipv4(
         strict:
             IP address string is strictly in CIDR notation.
         private:
-            IP address is public if `False`, private/local/loopback/broadcast if `True`.
+            IP address is public if `False`, private (RFC1918 for IPv4, ULA for IPv6) if `True`.
         host_bit:
             If `False` and host bits (along with network bits) _are_ set in the supplied
             address, this function raises a validation error. ref [IPv4Network][2].
@@ -88,14 +65,20 @@ def ipv4(
         if cidr:
             if strict and value.count("/") != 1:
                 raise ValueError("IPv4 address was expected in CIDR notation")
-            return IPv4Network(value, strict=not host_bit) and _check_private_ip(value, private)
-        return IPv4Address(value) and _check_private_ip(value, private)
+            network = IPv4Network(value, strict=not host_bit)
+            if private is not None and network.is_private != private:
+                return False
+            return True
+        address = IPv4Address(value)
+        if private is not None and address.is_private != private:
+            return False
+        return True
     except (ValueError, AddressValueError, NetmaskValueError):
         return False
 
 
 @validator
-def ipv6(value: str, /, *, cidr: bool = True, strict: bool = False, host_bit: bool = True):
+def ipv6(value: str, /, *, cidr: bool = True, strict: bool = False, host_bit: bool = True, private: Optional[bool] = None):
     """Returns if a given value is a valid IPv6 address.
 
     Including IPv4-mapped IPv6 addresses. The initial version of ipv6 validator
@@ -118,6 +101,8 @@ def ipv6(value: str, /, *, cidr: bool = True, strict: bool = False, host_bit: bo
             IP address string may contain CIDR annotation.
         strict:
             IP address string is strictly in CIDR notation.
+        private:
+            IP address is public if `False`, private (RFC1918 for IPv4, ULA for IPv6) if `True`.
         host_bit:
             If `False` and host bits (along with network bits) _are_ set in the supplied
             address, this function raises a validation error. ref [IPv6Network][2].
@@ -133,7 +118,13 @@ def ipv6(value: str, /, *, cidr: bool = True, strict: bool = False, host_bit: bo
         if cidr:
             if strict and value.count("/") != 1:
                 raise ValueError("IPv6 address was expected in CIDR notation")
-            return IPv6Network(value, strict=not host_bit)
-        return IPv6Address(value)
+            network = IPv6Network(value, strict=not host_bit)
+            if private is not None and network.is_private != private:
+                return False
+            return True
+        address = IPv6Address(value)
+        if private is not None and address.is_private != private:
+            return False
+        return True
     except (ValueError, AddressValueError, NetmaskValueError):
         return False


### PR DESCRIPTION
This PR removes the incorrect custom _check_private_ip function that misclassified multicast addresses and 0.0.0.0 as private, replacing it with Python's accurate is_private property for both IPv4 and IPv6.