### PR TITLE
Fix IBAN validator vulnerability with lowercase letter handling

### DIFF
--- a/src/validators/iban.py
+++ b/src/validators/iban.py
@@ -37,8 +37,9 @@ def iban(value: str, /):
         (Literal[True]): If `value` is a valid IBAN code.
         (ValidationError): If `value` is an invalid IBAN code.
     """
+    if not value:
+        return False
+    value = value.upper()
     return (
-        (re.match(r"^[a-z]{2}[0-9]{2}[a-z0-9]{11,30}$", value, re.IGNORECASE) and _mod_check(value))
-        if value
-        else False
+        re.match(r"^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$", value) and _mod_check(value)
     )


### PR DESCRIPTION
The IBAN validator had a case-sensitivity bug where valid IBAN codes in lowercase were incorrectly rejected. This occurred because the modulo-97 check assumed uppercase letters for conversion to numeric values, but the regex allowed lowercase input. The fix normalizes input to uppercase before validation.