### PR TITLE
Reject invalid and overlong domain names

### DIFF
--- a/src/validators/domain.py
+++ b/src/validators/domain.py
@@ -76,12 +76,21 @@ def domain(
     if not value:
         return False
 
-    if consider_tld and not _IanaTLD.check(value.rstrip(".").rsplit(".", 1)[-1].upper()):
-        return False
-
     try:
+        ascii_domain = value.encode("idna").decode("utf-8")
+        domain_without_trailing_dot = ascii_domain.rstrip(".")
+
+        if not domain_without_trailing_dot or len(domain_without_trailing_dot) > 253:
+            return False
+
+        if consider_tld and not _IanaTLD.check(
+            domain_without_trailing_dot.rsplit(".", 1)[-1].upper()
+        ):
+            return False
+
         service_record = r"_" if rfc_2782 else ""
         trailing_dot = r"\.?$" if rfc_1034 else r"$"
+        tld = r"(?:[a-z]{2,63}|xn--[a-z0-9](?:[a-z0-9-]{0,57}[a-z0-9])?)"
 
         return not re.search(r"\s|__+", value) and re.match(
             # First character of the domain
@@ -90,11 +99,9 @@ def domain(
             + rf"(?:[a-z0-9-{service_record}]{{0,61}}"
             # Hostname
             + rf"[a-z0-9{service_record}])?\.)"
-            # First 61 characters of the gTLD
-            + r"+[a-z0-9][a-z0-9-_]{0,61}"
-            # Last character of the gTLD
-            + rf"[a-z]{trailing_dot}",
-            value.encode("idna").decode("utf-8"),
+            # Top-level domain
+            + rf"+{tld}{trailing_dot}",
+            ascii_domain,
             re.IGNORECASE,
         )
     except UnicodeError as err:

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -77,6 +77,9 @@ def test_returns_true_on_valid_top_level_domain(
         ("123.123", False, False),
         ("123.123.123.", True, False),
         ("123.123.123.123", False, False),
+        ("example.c_m", False, False),
+        ("example.c-m", False, False),
+        (("a." * 200) + "com", False, False),
     ],
 )
 def test_returns_failed_validation_on_invalid_domain(value: str, rfc_1034: bool, rfc_2782: bool):

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -60,6 +60,9 @@ def test_returns_true_on_valid_hostname(value: str, rfc_1034: bool, rfc_2782: bo
         ("[dead:beef:0:-:0:-:42:1]:5731", False, False),
         ("[0:0:0:0:0:ffff:1.2.3.4]:-65538", False, False),
         ("[0:&:b:c:@:e:f:::9999", False, False),
+        ("example.c_m", False, False),
+        ("example.c-m", False, False),
+        (("a." * 200) + "com", False, False),
     ],
 )
 def test_returns_failed_validation_on_invalid_hostname(value: str, rfc_1034: bool, rfc_2782: bool):


### PR DESCRIPTION
Fixes a domain validation bypass where invalid TLDs containing _ or -, and domains longer than the DNS maximum length, were accepted by domain() and indirectly by hostname().