### PR TITLE
docs: correct PossibleValueTypes note in between to include None

### DIFF
--- a/src/validators/between.py
+++ b/src/validators/between.py
@@ -59,7 +59,7 @@ def between(
         (TypeError): If there's a type mismatch during comparison.
 
     Note:
-        - `PossibleValueTypes` = `TypeVar("PossibleValueTypes", int, float, str, datetime)`
+        - `PossibleValueTypes` = `TypeVar("PossibleValueTypes", int, float, str, datetime, None)`
         - If neither `min_val` nor `max_val` is provided, result will always be `True`.
     """
     if value is None:


### PR DESCRIPTION
The Note in the `between` docstring documents `PossibleValueTypes` as `TypeVar("PossibleValueTypes", int, float, str, datetime)`, but the actual definition in the module (line 11) includes `None` as a constraint: `TypeVar("PossibleValueTypes", int, float, str, datetime, None)`. This updates the docstring to match the code.