### PR TITLE
enforce 253 character limit in domain validator

### DIFF
--- a/src/validators/domain.py
+++ b/src/validators/domain.py
@@ -83,6 +83,11 @@ def domain(
         service_record = r"_" if rfc_2782 else ""
         trailing_dot = r"\.?$" if rfc_1034 else r"$"
 
+        encoded = value.encode("idna").decode("utf-8")
+        if len(encoded.rstrip(".")) > 253:
+            # ref: RFC 1035, presentation form is limited to 253 characters
+            return False
+
         return not re.search(r"\s|__+", value) and re.match(
             # First character of the domain
             rf"^(?:[a-z0-9{service_record}]"
@@ -94,7 +99,7 @@ def domain(
             + r"+[a-z0-9][a-z0-9-_]{0,61}"
             # Last character of the gTLD
             + rf"[a-z]{trailing_dot}",
-            value.encode("idna").decode("utf-8"),
+            encoded,
             re.IGNORECASE,
         )
     except UnicodeError as err:


### PR DESCRIPTION
domain() bounds each label to 63 characters but never caps the overall name length, so a string of valid labels totalling more than 253 characters passes (issue #413, and hostname() inherits it through domain()). The presentation form of a domain name is limited to 253 characters per RFC 1035, so reject anything longer after idna encoding, excluding an optional trailing dot. email() already applies the same cap on its domain part.