### PR TITLE
Accept trailing dot on simple hostnames with rfc_1034

### DIFF
--- a/src/validators/hostname.py
+++ b/src/validators/hostname.py
@@ -113,16 +113,25 @@ def hostname(
     if not value:
         return False
 
+    def _matches_simple_hostname(host: str):
+        if not maybe_simple:
+            return False
+        # A trailing dot (RFC 1034) is also valid on a simple, single-label
+        # hostname, not only on the dotted names handled by `domain()`.
+        if rfc_1034 and host.endswith("."):
+            host = host[:-1]
+        return _simple_hostname_regex().match(host)
+
     if may_have_port and (host_seg := _port_validator(value)):
         return (
-            (_simple_hostname_regex().match(host_seg) if maybe_simple else False)
+            _matches_simple_hostname(host_seg)
             or domain(host_seg, consider_tld=consider_tld, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
             or (False if skip_ipv4_addr else ipv4(host_seg, cidr=False, private=private))
             or (False if skip_ipv6_addr else ipv6(host_seg, cidr=False))
         )
 
     return (
-        (_simple_hostname_regex().match(value) if maybe_simple else False)
+        _matches_simple_hostname(value)
         or domain(value, consider_tld=consider_tld, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
         or (False if skip_ipv4_addr else ipv4(value, cidr=False, private=private))
         or (False if skip_ipv6_addr else ipv6(value, cidr=False))

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -15,6 +15,9 @@ from validators import ValidationError, hostname
         ("this-pc", False, False),
         ("lab-01a-notebook:404", False, False),
         ("4-oh-4", False, False),
+        # simple, single-label hostname w/ trailing dot (RFC 1034); see #442
+        ("this-pc.", True, False),
+        ("ie.", True, False),
         # hostname w/ optional ports
         ("example.com:4444", False, False),
         ("kräuter.com.", True, False),
@@ -45,6 +48,8 @@ def test_returns_true_on_valid_hostname(value: str, rfc_1034: bool, rfc_2782: bo
         ("this-pc-is-sh*t", False, False),
         ("lab-01a-note._com_.com:404", False, False),
         ("4-oh-4:@.com", False, False),
+        # trailing dot is only allowed with rfc_1034; see #442
+        ("this-pc.", False, False),
         # bad (hostname w/ optional ports)
         ("example.com:-4444", False, False),
         ("xn----gtbspbbmkef.xn--p1ai:65538", False, False),


### PR DESCRIPTION
## Summary

Refs #442.

`rfc_1034` is documented as "Allow trailing dot in domain/host name", but it only worked for dotted names (handled by `domain()`):

```python
>>> import validators
>>> validators.hostname("ie",  rfc_1034=True)   # True
>>> validators.hostname("ie.", rfc_1034=True)   # False  <- inconsistent
>>> validators.hostname("defo.ie.", rfc_1034=True)  # True
```

A simple, single-label hostname goes through `_simple_hostname_regex()`, which does not permit a trailing dot, so `"ie."` failed even with `rfc_1034=True`, while `"ie"` passed.

## Fix

Strip an optional trailing dot before the simple-hostname check when `rfc_1034` is set, so a single-label hostname behaves the same with and without the dot. The trailing dot is still rejected when `rfc_1034` is `False`.

```python
>>> validators.hostname("ie.",  rfc_1034=True)   # now True
>>> validators.hostname("ie.",  rfc_1034=False)  # still False
```

## Scope

This addresses the `hostname()` inconsistency from #442. I deliberately left `domain()`'s rejection of bare single-label names (`domain("ie")` → False with or without a dot) unchanged, since whether a single label counts as a "domain" is a separate policy question — happy to follow up if you'd like it changed too.

## Test plan

- Added single-label trailing-dot cases to `tests/test_hostname.py` (valid with `rfc_1034=True`, invalid without).
- `pytest tests/test_hostname.py tests/test_domain.py` — 90 passed.
- `ruff check` / `ruff format --check` — clean.
- Note: the full suite has 17 pre-existing, unrelated failures in `tests/crypto_addresses/test_eth_address.py` (present on a clean checkout, before this change).
