### PR TITLE
fix: correct broken ISIN checksum (validator accepted any check digit)

### DIFF
--- a/src/validators/finance.py
+++ b/src/validators/finance.py
@@ -32,21 +32,32 @@ def _cusip_checksum(cusip: str):
 
 
 def _isin_checksum(value: str):
-    check, val = 0, None
+    # The check digit (last character) is always numeric.
+    if not value[-1].isdecimal():
+        return False
 
+    # Expand the code into a string of digits, mapping each letter to its
+    # two-digit value (A=10, ..., Z=35) and leaving digits unchanged.
+    digits = ""
     for idx in range(12):
         c = value[idx]
         if c >= "0" and c <= "9" and idx > 1:
-            val = ord(c) - ord("0")
+            digits += c
         elif c >= "A" and c <= "Z":
-            val = 10 + ord(c) - ord("A")
+            digits += str(10 + ord(c) - ord("A"))
         elif c >= "a" and c <= "z":
-            val = 10 + ord(c) - ord("a")
+            digits += str(10 + ord(c) - ord("a"))
         else:
             return False
 
+    # Luhn checksum over the expanded digit string: starting from the
+    # rightmost digit, double every second digit and sum the resulting digits.
+    check = 0
+    for idx, c in enumerate(reversed(digits)):
+        val = ord(c) - ord("0")
         if idx & 1:
             val += val
+        check += (val // 10) + (val % 10)
 
     return (check % 10) == 0
 

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -24,13 +24,25 @@ def test_returns_failed_validation_on_invalid_cusip(value: str):
 # ==> ISIN <== #
 
 
-@pytest.mark.parametrize("value", ["US0004026250", "JP000K0VF054", "US0378331005"])
+@pytest.mark.parametrize("value", ["US0004026250", "US0378331005", "GB0002634946", "DE000BAY0017"])
 def test_returns_true_on_valid_isin(value: str):
     """Test returns true on valid isin."""
     assert isin(value)
 
 
-@pytest.mark.parametrize("value", ["010378331005", "XCVF", "00^^^1234", "A000009"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "010378331005",
+        "XCVF",
+        "00^^^1234",
+        "A000009",
+        # valid length and characters but wrong check digit
+        "US0378331006",
+        "US0004026251",
+        "GB0002634947",
+    ],
+)
 def test_returns_failed_validation_on_invalid_isin(value: str):
     """Test returns failed validation on invalid isin."""
     assert isinstance(isin(value), ValidationError)


### PR DESCRIPTION
## Problem

`_isin_checksum` never actually validates the check digit. It computes a per-character `val` inside the loop but never adds it to `check`:

```python
check, val = 0, None
for idx in range(12):
    ...
    val = ...        # computed
    if idx & 1:
        val += val   # still never added to check
return (check % 10) == 0   # check is always 0 -> always True
```

So `(check % 10) == 0` is always `True` and `isin()` accepts **any** 12-character string with valid characters, regardless of the check digit:

```python
isin('US0378331006')  # wrong check digit -> True (should be invalid)
isin('US0004026251')  # wrong check digit -> True
isin('AAAAAAAAAAAA')  # -> True
```

The existing "invalid" test cases (`010378331005`, `XCVF`, `00^^^1234`, `A000009`) are all rejected earlier by the length / character / `idx > 1` guards, so the checksum branch was effectively untested and the bug stayed hidden.

## Fix

Implement the actual ISO 6166 algorithm: the check digit must be numeric, expand each letter to its two-digit value (A=10 .. Z=35), then run a right-to-left Luhn sum over the expanded digit string.

I validated the new implementation against [`python-stdnum`](https://arthurdejong.org/python-stdnum/)'s authoritative `isin.is_valid` over 100k+ country-code-valid random inputs plus random fuzzing: **zero mismatches**.

## Tests

- Added wrong-check-digit cases (`US0378331006`, `US0004026251`, `GB0002634947`) to the invalid set. These fail on `master` and pass with the fix.
- Replaced `JP000K0VF054` in the valid set: it is **not** a valid ISIN (its check digit is wrong), it only passed before because the checksum did nothing. Substituted real valid ISINs (`GB0002634946`, `DE000BAY0017`).

`pytest tests/test_finance.py` is green (25 passed); `ruff check` and `ruff format --check` clean.