### PR TITLE
Return ValidationError instead of leaking AttributeError on non-string input

### DIFF
--- a/src/validators/utils.py
+++ b/src/validators/utils.py
@@ -91,7 +91,7 @@ def validator(func: Callable[..., Any]):
                     if func(*args, **kwargs)
                     else ValidationError(func, _func_args_as_dict(func, *args, **kwargs))
                 )
-        except (ValueError, TypeError, UnicodeError) as exp:
+        except (ValueError, TypeError, UnicodeError, AttributeError) as exp:
             if raise_validation_error:
                 raise ValidationError(
                     func, _func_args_as_dict(func, *args, **kwargs), str(exp)

--- a/tests/test_validation_failure.py
+++ b/tests/test_validation_failure.py
@@ -1,7 +1,11 @@
 """Test validation Failure."""
 
+# external
+import pytest
+
 # local
-from validators import between
+from validators import between, cron, email, hostname, uuid
+from validators.utils import ValidationError
 
 failed_obj_repr = "ValidationError(func=between"
 
@@ -31,3 +35,16 @@ class TestValidationError:
         assert self.is_in_between.__dict__["value"] == 3
         assert self.is_in_between.__dict__["min_val"] == 4
         assert self.is_in_between.__dict__["max_val"] == 5
+
+
+@pytest.mark.parametrize("validator", [uuid, email, hostname, cron])
+@pytest.mark.parametrize("value", [123, 1.5, True, ["x"], {"a": 1}])
+def test_returns_validation_error_on_non_string_input(validator, value):
+    """Wrong-typed input returns ValidationError, not a leaked exception.
+
+    These validators reach for string methods (e.g. ``.replace``/``.count``/
+    ``.strip``) on the value, which raises ``AttributeError`` for non-strings.
+    The decorator must convert that into a ``ValidationError`` like every other
+    invalid input, rather than letting it escape.
+    """
+    assert isinstance(validator(value), ValidationError)


### PR DESCRIPTION
## Summary

Several validators leak an uncaught `AttributeError` on non-string input instead of returning `ValidationError`:

```python
import validators
validators.uuid(123)       # AttributeError: 'int' object has no attribute 'replace'
validators.email(123)      # AttributeError: 'int' object has no attribute 'count'
validators.hostname(123)   # AttributeError: 'int' object has no attribute 'count'
validators.cron(123)       # AttributeError: 'int' object has no attribute 'strip'
```

This is inconsistent with the many validators that already return `ValidationError` for wrong-typed input (`domain`, `slug`, `md5`, `url`, `iban`, `mac_address`, …). Since a validator's job is to vet untrusted/unknown input, a caller reasonably passes a value of unknown type and expects `True`/`ValidationError` — not a crash.

## Cause

These validators reach for a string method on the value (`UUID(value)` → `value.replace(...)`, `value.count(...)`, `value.strip()`), which raises `AttributeError` for an `int`/`float`/`bool`/`list`/`dict`. The `@validator` decorator in `utils.py` converts `(ValueError, TypeError, UnicodeError)` into `ValidationError`, but `AttributeError` isn't in that set, so it escapes.

## Fix

Add `AttributeError` to the decorator's caught set. `AttributeError` from calling a string method on a non-string is squarely the "invalid input" category the decorator already handles for `TypeError`/`ValueError`, so this makes the whole class of validators handle non-string input uniformly — at the one place that defines the contract — and guards future validators from the same gap.

Added a cross-validator regression test (`test_returns_validation_error_on_non_string_input`, `uuid`/`email`/`hostname`/`cron` × `int`/`float`/`bool`/`list`/`dict`). Full suite: **915 passed** (was 895). `ruff check` / `ruff format --check` clean.

## Note / scope

I scoped this to the `AttributeError` class. Two validators (`es_doi`, `es_nie`) leak `KeyError` on some inputs via a different code path; I left those out deliberately, since catching `KeyError` globally in the decorator would risk masking genuine logic errors. Happy to address them separately if you'd like.

This pull request was prepared with the assistance of AI, under my direction and review.
