### PR TITLE
fix(crypto_addresses): correct testnet segwit prefix and reject non-hex ETH addresses

### DIFF
--- a/src/validators/crypto_addresses/btc_address.py
+++ b/src/validators/crypto_addresses/btc_address.py
@@ -50,7 +50,7 @@ def btc_address(value: str, /):
 
     return (
         # segwit pattern
-        re.compile(r"^(bc|tc)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
+        re.compile(r"^(bc|tb)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
         if value[:2] in ("bc", "tb")
         else _validate_old_btc_address(value)
     )

--- a/src/validators/crypto_addresses/eth_address.py
+++ b/src/validators/crypto_addresses/eth_address.py
@@ -17,10 +17,11 @@ except ImportError:
 def _validate_eth_checksum_address(addr: str):
     """Validate ETH type checksum address."""
     addr = addr.replace("0x", "")
-    addr_hash = keccak.new(addr.lower().encode("ascii")).digest().hex()  # type: ignore
 
-    if len(addr) != 40:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", addr):
         return False
+
+    addr_hash = keccak.new(addr.lower().encode("ascii")).digest().hex()  # type: ignore
 
     for i in range(0, 40):
         if (int(addr_hash[i], 16) > 7 and addr[i].upper() != addr[i]) or (

--- a/tests/crypto_addresses/test_btc_address.py
+++ b/tests/crypto_addresses/test_btc_address.py
@@ -17,6 +17,9 @@ from validators import ValidationError, btc_address
         # Bech32/segwit type
         "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
         "bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9",
+        # Bech32/segwit testnet (tb prefix)
+        "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
     ],
 )
 def test_returns_true_on_valid_btc_address(value: str):

--- a/tests/crypto_addresses/test_eth_address.py
+++ b/tests/crypto_addresses/test_eth_address.py
@@ -37,6 +37,8 @@ def test_returns_true_on_valid_eth_address(value: str):
         "0x7c8EE9977c6f96b6b9774b3e8e4Cc9B93B12b2c",
         "0x7Fb21a171205f3B8d8E4d88A2d2f8A56E45DdB5c",
         "validators.eth",
+        # non-hex characters (the checksum path used to accept these)
+        "0x" + "*" * 40,
     ],
 )
 def test_returns_failed_validation_on_invalid_eth_address(value: str):


### PR DESCRIPTION
This fixes two correctness bugs in the `crypto_addresses` validators. Both are covered by new regression tests, and the full test suite still passes.

## 1. `btc_address` rejects valid testnet segwit addresses

The segwit branch is selected when the value starts with `bc` or `tb`, but the regexp only matched `bc` or `tc`:

```python
re.compile(r"^(bc|tc)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
if value[:2] in ("bc", "tb")
else _validate_old_btc_address(value)
```

Because the gate accepts `tb` while the pattern expects `tc`, **every valid testnet bech32 address is rejected**:

```python
btc_address("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")  # ValidationError, should be valid
```

`tc` is not a valid Bitcoin HRP and is unreachable through the `value[:2] in ("bc", "tb")` gate, so it is a typo for `tb`. Fix: `(bc|tc)` → `(bc|tb)`. Mainnet `bc1...` is unaffected.

## 2. `eth_address` accepts non-hex "checksum" addresses

`_validate_eth_checksum_address` checked only the length of the stripped address, not that its characters were hexadecimal. The EIP-55 loop only constrains the *case* of letters, so caseless / non-hex characters pass it vacuously:

```python
eth_address("0x" + "*" * 40)  # True, should be invalid
```

Fix: require the stripped address to be exactly 40 hex digits before running the checksum (this also subsumes the previous length check).

## Tests

- `test_btc_address`: added two valid testnet bech32 addresses (BIP173 vectors) to the valid fixtures.
- `test_eth_address`: added a non-hex input to the invalid fixtures.

Both new cases fail on `master` and pass with this change. `ruff` reports no issues and the full suite (`898 passed`) is green.
