### PR TITLE
fix(card): mastercard() no longer accepts non-Mastercard 2-series BINs

### DIFF
--- a/src/validators/card.py
+++ b/src/validators/card.py
@@ -80,7 +80,7 @@ def mastercard(value: str, /):
         (Literal[True]): If `value` is a valid Mastercard card number.
         (ValidationError): If `value` is an invalid Mastercard card number.
     """
-    pattern = re.compile(r"^(51|52|53|54|55|22|23|24|25|26|27)")
+    pattern = re.compile(r"^(5[1-5]|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)")
     return card_number(value) and len(value) == 16 and pattern.match(value)
 
 

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -80,7 +80,13 @@ def test_returns_true_on_valid_mastercard(value: str):
 
 @pytest.mark.parametrize(
     "value",
-    visa_cards + amex_cards + unionpay_cards + diners_cards + jcb_cards + discover_cards,
+    visa_cards
+    + amex_cards
+    + unionpay_cards
+    + diners_cards
+    + jcb_cards
+    + discover_cards
+    + mir_cards,
 )
 def test_returns_failed_on_valid_mastercard(value: str):
     """Test returns failed on valid mastercard."""


### PR DESCRIPTION
## Summary

`mastercard()` accepts numbers that are not Mastercard. The Mastercard 2-series IIN range is **2221–2720**, but the prefix pattern matches `22|23|24|25|26|27` — i.e. anything from 2200 to 2799. So `2200–2220` and `2721–2799` pass as Mastercard.

This also collides with `mir()`: Mir cards begin with `2200–2204`, so the **same** number is reported as both Mir and Mastercard.

## Reproduction

```python
import validators

validators.mir('2200123456789019')         # True  (it is a Mir card)
validators.mastercard('2200123456789019')  # True  ← should be False
```

## Root cause

```python
pattern = re.compile(r"^(51|52|53|54|55|22|23|24|25|26|27)")
```

`22`–`27` is much wider than the real 2-series range (2221–2720).

## Fix

Match the precise 2-series sub-ranges:

```python
pattern = re.compile(r"^(5[1-5]|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)")
```

Valid Mastercard numbers (51–55 and 2221–2720) keep validating; 2200–2220 and 2721–2799 are now rejected.

## Tests

`test_returns_failed_on_valid_mastercard` already checks that every other network's cards are rejected by `mastercard()` — every list **except** `mir_cards`, the only omission, because those cards currently pass `mastercard()`. This PR adds `mir_cards` to that fixture: they fail on `master` and pass with the fix. The full test suite stays green and `ruff` is clean.
