### PR TITLE
fix(i18n): reject invalid input in ind_pan and fr_ssn

### DIFF
--- a/src/validators/i18n/fr.py
+++ b/src/validators/i18n/fr.py
@@ -13,10 +13,10 @@ from validators.utils import validator
 def _ssn_pattern():
     """SSN Pattern."""
     return re.compile(
-        r"^([1,2])"  # gender (1=M, 2=F)
+        r"^([12])"  # gender (1=M, 2=F)
         r"\s(\d{2})"  # year of birth
         r"\s(0[1-9]|1[0-2])"  # month of birth
-        r"\s(\d{2,3}|2[A,B])"  # department of birth
+        r"\s(\d{2,3}|2[AB])"  # department of birth
         r"\s(\d{2,3})"  # town of birth
         r"\s(\d{3})"  # registration number
         r"(?:\s(\d{2}))?$",  # control key (may or may not be provided)

--- a/src/validators/i18n/ind.py
+++ b/src/validators/i18n/ind.py
@@ -44,4 +44,4 @@ def ind_pan(value: str):
         (Literal[True]): If `value` is a valid PAN card number.
         (ValidationError): If `value` is an invalid PAN card number.
     """
-    return re.match(r"[A-Z]{5}\d{4}[A-Z]{1}", value)
+    return re.match(r"^[A-Z]{5}\d{4}[A-Z]{1}$", value)

--- a/tests/i18n/test_fr.py
+++ b/tests/i18n/test_fr.py
@@ -34,6 +34,7 @@ def test_returns_true_on_valid_ssn(value: str):
         (None,),
         ("",),
         ("3 84 12 76 451 089 46",),  # wrong gender number
+        (", 84 12 76 451 089",),  # comma is not a valid gender (regex char-class bug)
         ("1 84 12 76 451 089 47",),  # wrong control key
         ("1 84 00 76 451 089",),  # invalid month
         ("1 84 13 76 451 089",),  # invalid month

--- a/tests/i18n/test_ind.py
+++ b/tests/i18n/test_ind.py
@@ -26,7 +26,9 @@ def test_returns_true_on_valid_ind_pan(value: str):
     assert ind_pan(value)
 
 
-@pytest.mark.parametrize("value", ["ABC5d7896B", "417598346012", "AaaPL1234C"])
+@pytest.mark.parametrize(
+    "value", ["ABC5d7896B", "417598346012", "AaaPL1234C", "ABCDE9999KEXTRA"]
+)
 def test_returns_failed_validation_on_invalid_ind_pan(value: str):
     """Test returns failed validation on invalid ind pan."""
     assert isinstance(ind_pan(value), ValidationError)


### PR DESCRIPTION
Two small regex-correctness fixes in the i18n validators; each currently lets invalid input through. Both are covered by new regression tests that fail on `master` and pass with this change. `ruff` is clean and the full suite passes.

## `ind_pan` — trailing characters accepted

`ind_pan` used `re.match(r"[A-Z]{5}\d{4}[A-Z]{1}", value)` with no trailing `$`. `re.match` only anchors the start, so any string that *begins* with a valid PAN was accepted:

```python
>>> validators.ind_pan('ABCDE9999KEXTRA')   # truthy -> "valid", should be invalid
```

Anchored the pattern with `^…$`, matching the `ind_aadhar` pattern just above it.

## `fr_ssn` — comma accepted as gender / Corsica suffix

The SSN regex used the character classes `[1,2]` and `2[A,B]`, which also match a literal comma:

```python
>>> validators.fr_ssn(', 84 12 76 451 089')
True   # should be invalid
```

Dropped the commas (`[12]` and `[AB]`). Valid SSNs are unaffected.
