### PR TITLE
fix(cron): accept day-of-week 7 as a valid Sunday alias

### DIFF
--- a/src/validators/cron.py
+++ b/src/validators/cron.py
@@ -72,7 +72,7 @@ def cron(value: str, /):
         return False
     if not _validate_cron_component(months, 1, 12):
         return False
-    if not _validate_cron_component(weekdays, 0, 6):
+    if not _validate_cron_component(weekdays, 0, 7):
         return False
 
     return True

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -22,6 +22,9 @@ from validators import ValidationError, cron
         "0 3-6 * * *",
         "*/15 0,6,12,18 * * *",
         "0 12 * * 0",
+        "0 12 * * 7",
+        "0 0 * * 0-7",
+        "0 0 * * 0,7",
         "*/61 * * * *",
         # "5-10/2 * * * *", # this is valid, but not supported yet
     ],


### PR DESCRIPTION
## Bug

`validators.cron()` rejects valid cron expressions that use `7` for the day-of-week field. `7` is a well-documented alias for Sunday (the same as `0`), supported by all major cron implementations (vixie-cron, cronie, fcron, and crontab(5)).

```python
from validators import cron

cron('* * * * 7')    # ValidationError (incorrect — DOW 7 = Sunday)
cron('0 0 * * 0-7')  # ValidationError (incorrect — range ending at Sunday)
cron('0 0 * * 0,7')  # ValidationError (incorrect — Sunday listed twice)
```

## Root cause

In `src/validators/cron.py`, the weekdays component is validated with `max_val=6`:

```python
if not _validate_cron_component(weekdays, 0, 6):  # ← should be 7
    return False
```

## Fix

Change the upper bound from `6` to `7`. DOW `8` continues to be rejected (the existing test for `'0 12 * * 8'` still passes).

## Tests

Three new cases added to `test_returns_true_on_valid_cron`:
- `"0 12 * * 7"` — DOW=7 is Sunday
- `"0 0 * * 0-7"` — range 0–7 (Sunday to Sunday)
- `"0 0 * * 0,7"` — Sunday listed via both aliases

All 29 cron tests pass; the 17 pre-existing ETH address failures are unrelated.