### PR TITLE
Accept lowercase IBANs in iban()

### DIFF
--- a/src/validators/iban.py
+++ b/src/validators/iban.py
@@ -8,8 +8,8 @@ from .utils import validator
 
 
 def _char_value(char: str):
-    """A=10, B=11, ..., Z=35."""
-    return char if char.isdigit() else str(10 + ord(char) - ord("A"))
+    """A=10, B=11, ..., Z=35 (case-insensitive)."""
+    return char if char.isdigit() else str(10 + ord(char.upper()) - ord("A"))
 
 
 def _mod_check(value: str):

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -13,6 +13,12 @@ def test_returns_true_on_valid_iban(value: str):
     assert iban(value)
 
 
+@pytest.mark.parametrize("value", ["gb82west12345698765432", "No9386011117947"])
+def test_returns_true_on_valid_lowercase_iban(value: str):
+    """Lowercase/mixed-case IBANs are accepted (the format regex is case-insensitive)."""
+    assert iban(value)
+
+
 @pytest.mark.parametrize("value", ["GB81WEST12345698765432", "NO9186011117947"])
 def test_returns_failed_validation_on_invalid_iban(value: str):
     """Test returns failed validation on invalid iban."""


### PR DESCRIPTION
iban() treats lowercase input as well-formed (the regex has re.IGNORECASE and
[a-z0-9]) but then rejects it:

    iban("GB82WEST12345698765432")  # True
    iban("gb82west12345698765432")  # False, same IBAN

_char_value scores letters with 10 + ord(char) - ord("A"), which is only right
for uppercase, so lowercase letters get the wrong value and the mod-97 check
fails.

Upper-casing the char before scoring it fixes this. It only lets through inputs
that were already valid IBANs, so nothing that passed before changes. Added
lowercase and mixed-case cases to the tests.
