### PR TITLE
Reject domains longer than 253 characters

### DIFF
--- a/src/validators/domain.py
+++ b/src/validators/domain.py
@@ -76,6 +76,11 @@ def domain(
     if not value:
         return False
 
+    # The textual representation of a domain name is limited to 253 characters
+    # (RFC 1035), regardless of the individual label lengths.
+    if len(value.rstrip(".")) > 253:
+        return False
+
     if consider_tld and not _IanaTLD.check(value.rstrip(".").rsplit(".", 1)[-1].upper()):
         return False
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -84,6 +84,18 @@ def test_returns_failed_validation_on_invalid_domain(value: str, rfc_1034: bool,
     assert isinstance(domain(value, rfc_1034=rfc_1034, rfc_2782=rfc_2782), ValidationError)
 
 
+def test_returns_failed_validation_on_too_long_domain():
+    """A domain over 253 characters is invalid regardless of label lengths."""
+    label = "a" * 49
+    too_long = ".".join([label] * 5) + ".aaaaa"  # 255 characters, each label <= 63
+    assert len(too_long) > 253
+    assert isinstance(domain(too_long), ValidationError)
+
+    at_limit = ".".join([label] * 5) + ".aaa"  # exactly 253 characters
+    assert len(at_limit) == 253
+    assert domain(at_limit)
+
+
 @pytest.mark.parametrize(
     ("value", "consider_tld", "rfc_1034", "rfc_2782"),
     [


### PR DESCRIPTION
Fixes #413.

`domain()` validated each label (`{0,61}` + boundary chars, i.e. ≤ 63 characters per label) but never checked the **total** length. A name made of several valid-length labels could therefore exceed the RFC 1035 limit and still be accepted, and `hostname()` — which delegates to `domain()` — inherited the same gap:

```python
>>> long_name = ".".join(["a" * 49] * 5) + ".aaaaa"   # 255 chars, every label <= 63
>>> validators.hostname(long_name)   # was True
>>> validators.domain(long_name)     # was True
```

The textual representation of a domain name is limited to 253 characters (RFC 1035, one octet of the 255-octet wire limit is the root label). This adds that check to `domain()`, which fixes both `domain()` and `hostname()`.

- `domain()`/`hostname()` now reject the 255-character example above.
- A name of exactly 253 characters is still accepted (boundary covered by the new test).
- Existing valid domains are unaffected.

`tests/test_domain.py` + `tests/test_hostname.py`: `88 passed`. `ruff check` / `ruff format --check` clean.