### PR TITLE
fix(finance): validate the ISIN check digit (#440)

### DIFF
--- a/src/validators/finance.py
+++ b/src/validators/finance.py
@@ -32,21 +32,32 @@ def _cusip_checksum(cusip: str):
 
 
 def _isin_checksum(value: str):
-    check, val = 0, None
-
+    # Expand the ISIN to digits: each letter maps to two digits (A=10, ..., Z=35)
+    # while digits are kept as-is. The country code (first two characters) must be
+    # letters and the check digit (last character) must be numeric.
+    digits = ""
     for idx in range(12):
         c = value[idx]
-        if c >= "0" and c <= "9" and idx > 1:
-            val = ord(c) - ord("0")
+        if c >= "0" and c <= "9":
+            if idx < 2:
+                return False
+            digits += c
         elif c >= "A" and c <= "Z":
-            val = 10 + ord(c) - ord("A")
-        elif c >= "a" and c <= "z":
-            val = 10 + ord(c) - ord("a")
+            if idx == 11:
+                return False
+            digits += str(10 + ord(c) - ord("A"))
         else:
             return False
 
+    # Luhn checksum: doubling every second digit from the right.
+    check = 0
+    for idx, digit in enumerate(reversed(digits)):
+        val = int(digit)
         if idx & 1:
-            val += val
+            val *= 2
+            if val > 9:
+                val -= 9
+        check += val
 
     return (check % 10) == 0
 
@@ -82,10 +93,12 @@ def isin(value: str):
     [1]: https://en.wikipedia.org/wiki/International_Securities_Identification_Number
 
     Examples:
+        >>> isin('US0378331005')
+        True
+        >>> isin('US0378331004')
+        ValidationError(func=isin, args={'value': 'US0378331004'})
         >>> isin('037833DP2')
         ValidationError(func=isin, args={'value': '037833DP2'})
-        >>> isin('037833DP3')
-        ValidationError(func=isin, args={'value': '037833DP3'})
 
     Args:
         value: ISIN string to validate.

--- a/tests/test_finance.py
+++ b/tests/test_finance.py
@@ -24,13 +24,31 @@ def test_returns_failed_validation_on_invalid_cusip(value: str):
 # ==> ISIN <== #
 
 
-@pytest.mark.parametrize("value", ["US0004026250", "JP000K0VF054", "US0378331005"])
+@pytest.mark.parametrize(
+    "value",
+    ["US0004026250", "JP000K0VF055", "US0378331005", "AU0000XVGZA3", "GB0002634946"],
+)
 def test_returns_true_on_valid_isin(value: str):
     """Test returns true on valid isin."""
     assert isin(value)
 
 
-@pytest.mark.parametrize("value", ["010378331005", "XCVF", "00^^^1234", "A000009"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "010378331005",
+        "XCVF",
+        "00^^^1234",
+        "A000009",
+        # valid format but incorrect check digit (previously accepted, see gh-440)
+        "US0378331004",
+        "GB0002634947",
+        "AU0000XVGZA4",
+        "JP000K0VF054",
+        # lowercase country code is not a valid ISIN
+        "us0378331005",
+    ],
+)
 def test_returns_failed_validation_on_invalid_isin(value: str):
     """Test returns failed validation on invalid isin."""
     assert isinstance(isin(value), ValidationError)


### PR DESCRIPTION
## Summary

Fixes #440 (the ISIN portion). `validators.isin()` accepts **any** invalid ISIN check digit.

```python
>>> import validators
>>> bool(validators.isin("US0378331005"))   # Apple, genuinely valid
True
>>> bool(validators.isin("US0378331004"))   # same but wrong check digit
True                                          # <-- should be False
```

## Root cause

`_isin_checksum()` computes a per-character `val` and doubles it for odd positions, but **never accumulates it into `check`**:

```python
check, val = 0, None
for idx in range(12):
    ...
    if idx & 1:
        val += val      # doubles val, but val is then discarded
return (check % 10) == 0  # check is always 0 -> always True
```

So the checksum is never actually validated — every 12-character string with a two-letter country code and a trailing digit passes. (`_cusip_checksum` and `sedol` accumulate correctly and are unaffected.)

## Fix

Implement the real ISIN algorithm: expand letters to digits (`A=10 … Z=35`), keep digits as-is, then run the **Luhn** checksum over the resulting digit string. Also enforce that the country code (first two chars) is alphabetic and the check digit (last char) numeric, so lowercase/malformed inputs are rejected (as the issue requests).

## Verification

- Validated against `python-stdnum`'s ISIN validator: my implementation agrees on every case tested (real ISINs for Apple/Microsoft/BAE/Alphabet/Bayer/etc. → valid; wrong-check-digit variants → invalid).
- This cross-check also revealed the existing **test fixture `JP000K0VF054` was itself an invalid ISIN** (correct check digit is `5`); it only passed before because the checksum was never computed. Corrected to `JP000K0VF055` and added wrong-check-digit fixtures.
- New tests fail on `master` and pass with this change. `tests/test_finance.py`: 31 passed (incl. doctests), up from 21.
- `ruff check` and `ruff format --check` clean on the changed files.
- The 17 pre-existing `tests/crypto_addresses/test_eth_address.py` failures are unrelated (they fail identically on `master`).

---

*Disclosure: prepared with AI assistance; reviewed and cross-checked locally (incl. against `python-stdnum`).*
