### PR TITLE
fix: require both control digits for 12-digit INN

### DIFF
--- a/src/validators/i18n/ru.py
+++ b/src/validators/i18n/ru.py
@@ -39,23 +39,17 @@ def ru_inn(value: str):
         if len(digits) == 10:
             weight_coefs = [2, 4, 10, 3, 5, 9, 4, 6, 8, 0]
             control_number = sum([d * w for d, w in zip(digits, weight_coefs)]) % 11
-            return (
-                (control_number % 10) == digits[-1]
-                if control_number > 9
-                else control_number == digits[-1]
-            )
+            return control_number % 10 == digits[-1]
         # person
         elif len(digits) == 12:
             weight_coefs1 = [7, 2, 4, 10, 3, 5, 9, 4, 6, 8, 0, 0]
             control_number1 = sum([d * w for d, w in zip(digits, weight_coefs1)]) % 11
             weight_coefs2 = [3, 7, 2, 4, 10, 3, 5, 9, 4, 6, 8, 0]
             control_number2 = sum([d * w for d, w in zip(digits, weight_coefs2)]) % 11
+            # Both controls must match (% 10 maps 10 -> 0 per INN rules).
             return (
-                (control_number1 % 10) == digits[-2]
-                if control_number1 > 9
-                else control_number1 == digits[-2] and (control_number2 % 10) == digits[-1]
-                if control_number2 > 9
-                else control_number2 == digits[-1]
+                control_number1 % 10 == digits[-2]
+                and control_number2 % 10 == digits[-1]
             )
         else:
             return False

--- a/tests/i18n/test_ru.py
+++ b/tests/i18n/test_ru.py
@@ -41,8 +41,10 @@ def test_returns_true_on_valid_ru_inn(value: str):
         ("7707012149",),
         ("140700989886",),
         ("774334078054",),
+        ("000000000018",),
+        ("000000000400",),
     ],
 )
-def test_returns_false_on_valid_ru_inn(value: str):
-    """Test returns true on valid russian individual tax number."""
+def test_returns_false_on_invalid_ru_inn(value: str):
+    """Test returns ValidationError on invalid russian individual tax number."""
     assert isinstance(ru_inn(value), ValidationError)


### PR DESCRIPTION
validators.i18n.ru.ru_inn hits false-accept when 12-digit INN ternary precedence skips first control digit when both controls <=9. This PR fixes the regression with a focused test covering the case.