### PR TITLE
fix(domain): accept single-label TLDs erroneously rejected by domain() and hostname()

### DIFF
--- a/src/validators/domain.py
+++ b/src/validators/domain.py
@@ -51,6 +51,11 @@ def domain(
         >>> # Supports IDN domains as well::
         >>> domain('xn----gtbspbbmkef.xn--p1ai')
         True
+        >>> # Bare TLDs are valid single-label domain names (RFC 1034 §2.3.1):
+        >>> domain('ie')
+        True
+        >>> domain('ie.', rfc_1034=True)
+        True
 
     Args:
         value:
@@ -82,8 +87,13 @@ def domain(
     try:
         service_record = r"_" if rfc_2782 else ""
         trailing_dot = r"\.?$" if rfc_1034 else r"$"
+        encoded = value.encode("idna").decode("utf-8")
 
-        return not re.search(r"\s|__+", value) and re.match(
+        if re.search(r"\s|__+", value):
+            return False
+
+        # Multi-label domain (e.g. example.com, defo.ie, yugoslavia.yu)
+        if re.match(
             # First character of the domain
             rf"^(?:[a-z0-9{service_record}]"
             # Sub-domain
@@ -94,8 +104,18 @@ def domain(
             + r"+[a-z0-9][a-z0-9-_]{0,61}"
             # Last character of the gTLD
             + rf"[a-z]{trailing_dot}",
-            value.encode("idna").decode("utf-8"),
+            encoded,
             re.IGNORECASE,
+        ):
+            return True
+
+        # Single-label domain / bare TLD (e.g. ie, com, yu).
+        # RFC 1034 §2.3.1 permits a single label of 1-63 characters.
+        # We require at least 2 alpha chars so pure-digit strings ("123")
+        # are still rejected, matching the behaviour of the multi-label path.
+        return bool(
+            re.match(rf"^[a-z]{{2,63}}{trailing_dot}", encoded, re.IGNORECASE)
         )
+
     except UnicodeError as err:
         raise UnicodeError(f"Unable to encode/decode {value}") from err


### PR DESCRIPTION
Fixes #442.

domain() and hostname() with fc_1034=True rejected valid single-label domain names (ie, com, yu, ie.) because the internal regex used a + quantifier on the label group — which forces at least one dot separator. So a bare TLD like ie never matched.

Multi-label names like defo.ie and yugoslavia.yu were fine; only the single-label case was broken.

RFC 1034 §2.3.1 explicitly permits single-label names. The fix adds a second match path after the existing multi-label path: a bare TLD must be 2-63 alpha characters (optionally followed by a trailing dot when fc_1034=True). Pure-digit strings like 123 are still rejected, consistent with the multi-label path.

**Before:**
\\\python
domain('ie')        # ValidationError  (wrong)
domain('ie.')       # ValidationError  (wrong)
domain('com')       # ValidationError  (wrong)
hostname('ie.', rfc_1034=True)  # ValidationError  (wrong)
\\\

**After:**
\\\python
domain('ie')        # True
domain('ie.', rfc_1034=True)   # True
domain('ie.')       # ValidationError  (correct — trailing dot only allowed with rfc_1034)
domain('com')       # True
hostname('ie.', rfc_1034=True) # True
domain('123')       # ValidationError  (still rejected)
\\\

Multi-label domains, IDN, and all existing behaviour unchanged.