### PR TITLE
Fix BTC segwit regex to accept testnet (tb) addresses

### DIFF
--- a/src/validators/crypto_addresses/btc_address.py
+++ b/src/validators/crypto_addresses/btc_address.py
@@ -50,7 +50,7 @@ def btc_address(value: str, /):
 
     return (
         # segwit pattern
-        re.compile(r"^(bc|tc)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
+        re.compile(r"^(bc|tb)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
         if value[:2] in ("bc", "tb")
         else _validate_old_btc_address(value)
     )

--- a/tests/crypto_addresses/test_btc_address.py
+++ b/tests/crypto_addresses/test_btc_address.py
@@ -17,6 +17,8 @@ from validators import ValidationError, btc_address
         # Bech32/segwit type
         "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
         "bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9",
+        # Bech32/segwit type, testnet (tb) HRP
+        "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
     ],
 )
 def test_returns_true_on_valid_btc_address(value: str):


### PR DESCRIPTION
## Summary

`btc_address()` rejects every valid **testnet** bech32/segwit address.

The segwit branch is guarded by:

```python
if value[:2] in ("bc", "tb")
```

so both mainnet (`bc`) and testnet (`tb`) HRPs are routed into the regex — but the regex only accepts `bc` or `tc`:

```python
re.compile(r"^(bc|tc)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
```

`tc` is not a valid Bitcoin human-readable part (mainnet is `bc`, testnet is `tb` — see BIP173). Because the guard never lets a `tc`-prefixed value reach the regex, the `tc` alternative is dead code; the intended prefix is clearly `tb`. As written, any `tb...` address matches the guard, then fails the regex, and `btc_address` returns a `ValidationError`.

## Reproduction

```python
>>> from validators import btc_address
>>> btc_address("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")  # canonical BIP173 testnet
ValidationError(func=btc_address, ...)   # should be True
>>> btc_address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")  # mainnet
True
```

## Fix

```diff
-        re.compile(r"^(bc|tc)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
+        re.compile(r"^(bc|tb)[0-3][02-9ac-hj-np-z]{14,74}$").match(value)
```

## Tests

Added the canonical BIP173 testnet address to the valid-address cases in `tests/crypto_addresses/test_btc_address.py`. It fails on the current code and passes with the fix; the full file passes (9 tests).
