### PR TITLE
Systematically enforce full-string matching for Indian PAN validation

### DIFF
--- a/src/validators/i18n/ind.py
+++ b/src/validators/i18n/ind.py
@@ -44,4 +44,4 @@ def ind_pan(value: str):
         (Literal[True]): If `value` is a valid PAN card number.
         (ValidationError): If `value` is an invalid PAN card number.
     """
-    return re.match(r"[A-Z]{5}\d{4}[A-Z]{1}", value)
+    return re.fullmatch(r"[A-Z]{5}\d{4}[A-Z]{1}", value)

--- a/tests/i18n/test_ind.py
+++ b/tests/i18n/test_ind.py
@@ -26,7 +26,9 @@ def test_returns_true_on_valid_ind_pan(value: str):
     assert ind_pan(value)
 
 
-@pytest.mark.parametrize("value", ["ABC5d7896B", "417598346012", "AaaPL1234C"])
+@pytest.mark.parametrize(
+    "value", ["ABC5d7896B", "417598346012", "AaaPL1234C", "ABCDE9999Kextra", "ABCDE9999K "]
+)
 def test_returns_failed_validation_on_invalid_ind_pan(value: str):
     """Test returns failed validation on invalid ind pan."""
     assert isinstance(ind_pan(value), ValidationError)


### PR DESCRIPTION
Replace prefix-oriented regex matching in the Indian PAN validator with `re.fullmatch`, ensuring that otherwise valid PAN prefixes followed by arbitrary trailing data are rejected.

`ind_pan()` currently uses `re.match(r"[A-Z]{5}\\d{4}[A-Z]{1}", value)`, which is not end-anchored. Any string that merely *begins* with a syntactically valid 10-character PAN is accepted, even with arbitrary trailing characters (e.g. `"ABCDE9999Kextra"`, `"ABCDE9999K "`). The neighboring `ind_aadhar` validator in the same file is already end-anchored, so this looks like an unintentional asymmetry rather than deliberate prefix matching.

This is a small, low-risk change (one line) plus two additional regression cases added to the existing parametrized test in `tests/i18n/test_ind.py`. Full test file passes locally (12/12).