### PR TITLE
Let hostname() accept a bare single-label name with the RFC 1034 dot

### DIFF
--- a/src/validators/hostname.py
+++ b/src/validators/hostname.py
@@ -29,6 +29,20 @@ def _simple_hostname_regex():
     return re.compile(r"^(?!-)[a-z0-9](?:[a-z0-9-]{0,59}[a-z0-9])?(?<!-)$", re.IGNORECASE)
 
 
+def _simple_hostname_match(value: str, rfc_1034: bool):
+    """Match value against the simple hostname regex.
+
+    rfc_1034 promises an optional trailing dot is allowed, but the simple
+    regex above has no notion of one, so a bare single-label name like
+    "yu" would pass without the dot and fail with it. Strip a lone
+    trailing dot first when that flag is set, same as domain() already
+    does for its own regex, so the two paths agree.
+    """
+    if rfc_1034 and value.endswith(".") and len(value) > 1:
+        value = value[:-1]
+    return _simple_hostname_regex().match(value)
+
+
 def _port_validator(value: str):
     """Returns host segment if port is valid."""
     if value.count("]:") == 1:
@@ -115,14 +129,14 @@ def hostname(
 
     if may_have_port and (host_seg := _port_validator(value)):
         return (
-            (_simple_hostname_regex().match(host_seg) if maybe_simple else False)
+            (_simple_hostname_match(host_seg, rfc_1034) if maybe_simple else False)
             or domain(host_seg, consider_tld=consider_tld, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
             or (False if skip_ipv4_addr else ipv4(host_seg, cidr=False, private=private))
             or (False if skip_ipv6_addr else ipv6(host_seg, cidr=False))
         )
 
     return (
-        (_simple_hostname_regex().match(value) if maybe_simple else False)
+        (_simple_hostname_match(value, rfc_1034) if maybe_simple else False)
         or domain(value, consider_tld=consider_tld, rfc_1034=rfc_1034, rfc_2782=rfc_2782)
         or (False if skip_ipv4_addr else ipv4(value, cidr=False, private=private))
         or (False if skip_ipv6_addr else ipv6(value, cidr=False))

--- a/tests/test_hostname.py
+++ b/tests/test_hostname.py
@@ -30,6 +30,9 @@ from validators import ValidationError, hostname
         ("[dead:beef:0:0:0:0000:42:1]:5731", False, False),
         ("[0:0:0:0:0:ffff:1.2.3.4]:80", False, False),
         ("[0:a:b:c:d:e:f::]:53", False, False),
+        # bare single-label name with the RFC 1034 trailing dot, GH-442
+        ("yu.", True, False),
+        ("yu.:443", True, False),
     ],
 )
 def test_returns_true_on_valid_hostname(value: str, rfc_1034: bool, rfc_2782: bool):
@@ -60,6 +63,10 @@ def test_returns_true_on_valid_hostname(value: str, rfc_1034: bool, rfc_2782: bo
         ("[dead:beef:0:-:0:-:42:1]:5731", False, False),
         ("[0:0:0:0:0:ffff:1.2.3.4]:-65538", False, False),
         ("[0:&:b:c:@:e:f:::9999", False, False),
+        # bad (trailing dot only allowed when rfc_1034 is requested)
+        ("yu.", False, False),
+        # bad (a lone dot has no label to strip down to)
+        (".", True, False),
     ],
 )
 def test_returns_failed_validation_on_invalid_hostname(value: str, rfc_1034: bool, rfc_2782: bool):


### PR DESCRIPTION
Fixes #442, at least the hostname() half of it.

hostname("yu", rfc_1034=True) already passes today, through the maybe_simple fast path, since _simple_hostname_regex doesn't care whether a lone alphanumeric label has a dot after it or not. hostname("yu.", rfc_1034=True) doesn't pass, though, because that regex has no notion of a trailing dot at all, and falling back to domain() needs at least a second label before the TLD. So the exact same name gets accepted or rejected depending only on whether it carries the dot that rfc_1034 is supposed to permit, which is the wrong way around.

Fix: strip a lone trailing dot before running the simple-hostname match when rfc_1034 is set, the same thing domain() already does for its own regex a bit further down. Everything else about the simple path is untouched, so this shouldn't move the needle for the vast majority of callers who never pass rfc_1034.

I looked at domain()'s own half of the issue too (a bare TLD with no second label at all, e.g. "com" or "com."), but that's a bigger question about whether a single label should count as a "domain" on its own, separate from the hostname() inconsistency this PR closes. Left that alone rather than guess at the intended scope.

Added two new cases to the existing parametrized true/false tests in test_hostname.py rather than a separate test function, since they slot into the same shape already there. Confirmed via git stash that both new true-cases fail on unpatched code with the same ValidationError from the issue, and pass with the fix. Full local suite: 882 passing (17 unrelated failures from crypto_addresses/test_eth_address.py needing an optional extra that isn't installed here, same before and after this change).