### PR TITLE
Stop uuid() from accepting urn:/braced forms via dead-code fallback

### DIFF
--- a/src/validators/uuid.py
+++ b/src/validators/uuid.py
@@ -35,9 +35,9 @@ def uuid(value: Union[str, UUID], /):
         return False
     if isinstance(value, UUID):
         return True
-    try:
-        return UUID(value) or re.match(
-            r"^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$", value
-        )
-    except ValueError:
-        return False
+    # Deliberately not delegating to the stdlib UUID() constructor here:
+    # it accepts far more than this validator documents or tests, e.g.
+    # `urn:uuid:...`-prefixed and `{braced}` forms, and any UUID version
+    # (not just v4). A regex keeps acceptance limited to the plain
+    # (optionally dashed) hex form shown in the docstring and tests.
+    return bool(re.match(r"^[0-9a-fA-F]{8}-?([0-9a-fA-F]{4}-?){3}[0-9a-fA-F]{12}$", value))

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -32,6 +32,13 @@ def test_returns_true_on_valid_uuid(value: Union[str, UUID]):
         ("2bc1c94f-0deb-43e9-92a1-4775189ec9f",),
         ("gbc1c94f-0deb-43e9-92a1-4775189ec9f8",),
         ("2bc1c94f 0deb-43e9-92a1-4775189ec9f8",),
+        # Regression: the previous implementation delegated to the stdlib
+        # UUID() constructor, which is far more permissive than this
+        # validator's own docstring/regex -- it also accepts urn:-prefixed
+        # and {braced} forms, neither of which were ever documented,
+        # tested, or intended to pass here.
+        ("urn:uuid:2bc1c94f-0deb-43e9-92a1-4775189ec9f8",),
+        ("{2bc1c94f-0deb-43e9-92a1-4775189ec9f8}",),
     ],
 )
 def test_returns_failed_validation_on_invalid_uuid(value: Union[str, UUID]):


### PR DESCRIPTION
## The bug

`uuid()` builds its result like this:

```python
try:
    return UUID(value) or re.match(
        r"^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$", value
    )
except ValueError:
    return False
```

A successfully-parsed `UUID` object is always truthy (no `__bool__`/`__len__`), so `or re.match(...)` is unreachable dead code. The real acceptance criteria has always been "whatever `UUID()` accepts", not the regex the code appears to enforce — and `UUID()` accepts a lot more than this validator documents or tests:

```pycon
>>> uuid('urn:uuid:2bc1c94f-0deb-43e9-92a1-4775189ec9f8')
True   # should be rejected
>>> uuid('{2bc1c94f-0deb-43e9-92a1-4775189ec9f8}')
True   # should be rejected
```

Neither form is in the docstring, tests, or (as far as I could find via GitHub search) any prior issue/PR. The closest related history is #112/#175, about accepting hyphen-less hex — that's an intentional, tested feature this fix keeps working.

## The fix

Drop the `UUID()`-based parsing and validate directly with a regex, extended to also accept the already-tested hyphen-less form:

```python
return bool(re.match(r"^[0-9a-fA-F]{8}-?([0-9a-fA-F]{4}-?){3}[0-9a-fA-F]{12}$", value))
```

This is a strict subset of what the old code's own regex/docstring described as valid — I deliberately didn't try to guess at any *broader* intended behavior (e.g. version-nibble checks despite the "UUID-v4" docstring wording), since that would be speculative about intent rather than fixing a demonstrated bug.

## Verification

- All 8 existing `test_uuid.py` cases pass unchanged.
- Added 2 regression cases (`urn:uuid:...`, `{...}`) to the existing invalid-input parametrize list. Confirmed they fail against the unpatched code (reverted locally to double-check) and pass with the fix.
- Non-string inputs (`123`, `1.5`, `True`, `['x']`, `{'a': 1}`, `None`) still resolve to `ValidationError` rather than crashing — `TypeError` from `re.match` on a non-string is already caught by `@validator` in `utils.py`, so no new exception handling needed.
- Full suite: `pytest tests/` — 897 passed (895 baseline + 2 new), 0 regressions.
- `pytest --doctest-modules src/validators/` — 57 passed.
- `ruff format --check`, `ruff check`, `pyright` all clean on the changed files — matches this repo's `pycqa.yaml` CI job exactly.

---
Found via targeted review of validator internals (differential testing across the library's public functions caught the over-permissive acceptance surface), not from a filed issue. AI-assisted (Code Puppy); reproduced, root-caused, fixed, and verified bidirectionally before opening this.
